### PR TITLE
Fix: [BUG-019] Fix test_dayofmonth column name mismatch

### DIFF
--- a/tests/parity/functions/test_datetime.py
+++ b/tests/parity/functions/test_datetime.py
@@ -30,7 +30,7 @@ class TestDatetimeFunctionsParity(ParityTestBase):
         """Test dayofmonth function matches PySpark behavior."""
         expected = self.load_expected("datetime", "dayofmonth")
         df = spark.createDataFrame(expected["input_data"])
-        result = df.select(F.dayofmonth(df.hire_date))
+        result = df.select(F.dayofmonth(df.date))
         self.assert_parity(result, expected)
 
     def test_dayofweek(self, spark):


### PR DESCRIPTION
## Description

Fixes BUG-019 by correcting the test to use the correct column name. The `dayofmonth` function itself was working correctly - the issue was that the test was referencing a column name that didn't exist in the expected output data.

## Changes

- Fixed `test_dayofmonth` to use `df.date` instead of `df.hire_date`
- The expected output has columns: `id`, `date`, `timestamp`
- The test was incorrectly trying to use `hire_date` which doesn't exist

## Impact

- Fixes 1 test failure (`test_dayofmonth`)
- `dayofmonth` function was already working correctly
- Test now correctly validates dayofmonth function parity with PySpark

## Tests

- `test_dayofmonth` now passes
- All datetime function tests continue to pass

Fixes #20