### PR TITLE
Add BUG-018 null-handling column name regression test

### DIFF
--- a/tests/unit/functions/test_null_handling_column_names.py
+++ b/tests/unit/functions/test_null_handling_column_names.py
@@ -1,0 +1,25 @@
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_coalesce_column_name_matches_expected() -> None:
+    """BUG-018 regression: coalesce should use PySpark-compatible column naming.
+
+    The parity JSON for null_handling/coalesce expects a single column named
+    \"coalesce(salary, 0)\"; this test asserts that the DataFrame produced by
+    the corresponding operation uses that exact column name.
+    """
+    spark = SparkSession("Bug018NullHandling")
+    try:
+        df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Alice", "age": 25, "salary": 50000.0},
+                {"id": 2, "name": None, "age": 30, "salary": None},
+            ]
+        )
+
+        result = df.select(F.coalesce(df.salary, F.lit(0)))
+        assert result.columns == ["coalesce(salary, 0)"]
+    finally:
+        spark.stop()
+
+


### PR DESCRIPTION
BUG-018 reported null-handling tests failing due to mismatched column names. The functional behavior has since been aligned; this PR adds a focused regression test that:\n\n- Constructs a DataFrame with a salary column and applies F.coalesce(df.salary, F.lit(0)).\n- Asserts that the resulting column is named 'coalesce(salary, 0)', matching the null_handling/coalesce expected output JSON.\n\nExisting null-handling parity tests continue to pass, and this test guards the expected naming convention going forward.