### PR TITLE
Docs for BUG-021 SQL basic SELECT schema behavior

### DIFF
--- a/sparkless/session/sql/executor.py
+++ b/sparkless/session/sql/executor.py
@@ -113,6 +113,15 @@ class SQLExecutor:
     def _execute_select(self, ast: SQLAST) -> IDataFrame:
         """Execute SELECT query.
 
+        Notes (BUG-021 - schema parity):
+            Basic SELECT queries must preserve a PySpark-compatible schema:
+            - ``SELECT * FROM table`` returns the full table schema.
+            - ``SELECT id, name, age FROM table`` projects exactly those
+              columns, in order.
+            This behavior is covered by:
+            - ``tests/unit/session/test_sql_basic_select_schema.py``
+            - ``tests/parity/sql/test_queries.py::TestSQLQueriesParity``.
+
         Args:
             ast: Parsed SQL AST.
 


### PR DESCRIPTION
BUG-021 reported schema mismatches for basic SQL SELECT queries. The underlying behavior is now correct and verified by:\n\n- tests/unit/session/test_sql_basic_select_schema.py\n- tests/parity/sql/test_queries.py::TestSQLQueriesParity::test_basic_select\n\nThis PR documents the expected PySpark-compatible schema behavior for SELECT queries directly in _execute_select, so future changes are guided by the existing tests and bug context.