### PR TITLE
BUG-008/022: document subquery support and relax agg validation

### DIFF
--- a/sparkless/dataframe/grouped/base.py
+++ b/sparkless/dataframe/grouped/base.py
@@ -77,7 +77,13 @@ class GroupedData:
         if not is_dict_syntax:
             for i, expr in enumerate(exprs):
                 # Allow strings for backward compatibility
-                if not isinstance(expr, str) and not (is_column(expr) or is_column_operation(expr)):
+                if isinstance(expr, str):
+                    continue
+                # Allow AggregateFunction instances - they are handled explicitly
+                # later in this method (see the AggregateFunction branch below).
+                if isinstance(expr, AggregateFunction):
+                    continue
+                if not (is_column(expr) or is_column_operation(expr)):
                     raise AssertionError(
                         f"all exprs should be Column, got {type(expr).__name__} at argument {i}"
                     )

--- a/sparkless/session/sql/executor.py
+++ b/sparkless/session/sql/executor.py
@@ -291,9 +291,13 @@ class SQLExecutor:
             # Parse simple WHERE conditions like "column > value", "column < value", etc.
             where_condition = where_conditions[0]
             
-            # Handle subqueries in WHERE conditions (e.g., "column > (SELECT AVG(col) FROM table)")
-            # Extract and execute subqueries first, then replace them with their scalar results
-            # Use proper parenthesis matching to handle nested parentheses in aggregate functions
+            # Handle subqueries in WHERE conditions (e.g., "column > (SELECT AVG(col) FROM table)").
+            # This logic was introduced as part of BUG-008 (SQL subqueries support) and is
+            # exercised by:
+            #   - tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_subquery
+            # It works by extracting nested SELECT subqueries, executing them recursively via
+            # _execute_select, and replacing them with their scalar results before applying
+            # the remaining WHERE filters.
             def extract_subquery(text: str) -> str | None:
                 """Extract first subquery from text, handling nested parentheses."""
                 start = text.find("(SELECT")


### PR DESCRIPTION
This PR finalizes BUG-008 and BUG-022 work by:\n\n- Documenting SQL subquery handling in _execute_select, with a direct reference to tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_subquery.\n- Relaxing GroupedData.agg() validation so AggregateFunction instances are accepted and handled in their dedicated branch, while keeping strict checks for other types.\n\nAggregate parity tests and the AggregateFunction regression test now pass on main.