### PR TITLE
Add BUG-009 SQL LIKE clause regression test

### DIFF
--- a/tests/unit/session/test_sql_like_clause.py
+++ b/tests/unit/session/test_sql_like_clause.py
@@ -1,0 +1,19 @@
+from sparkless.sql import SparkSession
+
+
+def test_sql_like_simple_prefix_pattern() -> None:
+    """BUG-009 regression: basic LIKE 'A%' pattern should work in SQL."""
+    spark = SparkSession("Bug009Like")
+    try:
+        df = spark.createDataFrame([("Alice",), ("Bob",), ("Anna",)], ["name"])
+        df.write.mode("overwrite").saveAsTable("like_unit_test")
+
+        result = spark.sql("SELECT * FROM like_unit_test WHERE name LIKE 'A%'")
+        names = sorted(row["name"] for row in result.collect())
+
+        assert names == ["Alice", "Anna"]
+    finally:
+        spark.sql("DROP TABLE IF EXISTS like_unit_test")
+        spark.stop()
+
+


### PR DESCRIPTION
BUG-009 reported SQL LIKE clause parsing issues. Current behavior matches PySpark, and this PR adds a focused regression test that:\n\n- Creates a simple table and runs SELECT ... WHERE name LIKE 'A%'.\n- Asserts that names starting with 'A' (Alice, Anna) are returned.\n\nTogether with the existing parity test in tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_like, this guards the LIKE behavior going forward.