### PR TITLE
Add BUG-010 SQL IN clause regression test

### DIFF
--- a/tests/unit/session/test_sql_in_clause.py
+++ b/tests/unit/session/test_sql_in_clause.py
@@ -1,0 +1,19 @@
+from sparkless.sql import SparkSession
+
+
+def test_sql_in_clause_basic() -> None:
+    """BUG-010 regression: basic IN (25, 35) should filter correctly."""
+    spark = SparkSession("Bug010InClause")
+    try:
+        df = spark.createDataFrame([("Alice", 25), ("Bob", 30), ("Charlie", 35)], ["name", "age"])
+        df.write.mode("overwrite").saveAsTable("in_unit_test")
+
+        result = spark.sql("SELECT * FROM in_unit_test WHERE age IN (25, 35)")
+        names = sorted(row["name"] for row in result.collect())
+
+        assert names == ["Alice", "Charlie"]
+    finally:
+        spark.sql("DROP TABLE IF EXISTS in_unit_test")
+        spark.stop()
+
+


### PR DESCRIPTION
BUG-010 reported SQL IN clause parsing/execution issues. Current behavior matches PySpark, and this PR adds a focused regression test that:\n\n- Creates a simple table and runs SELECT ... WHERE age IN (25, 35).\n- Asserts that only the expected rows (Alice, Charlie) are returned.\n\nTogether with tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_in_clause, this guards IN-clause behavior going forward.