### PR TITLE
Add BUG-011 CREATE TABLE AS SELECT regression test

### DIFF
--- a/tests/unit/session/test_sql_create_table_as_select.py
+++ b/tests/unit/session/test_sql_create_table_as_select.py
@@ -1,0 +1,36 @@
+from sparkless.sql import SparkSession
+
+
+def test_create_table_as_select_basic() -> None:
+    """BUG-011 regression: CREATE TABLE AS SELECT should create a table from a query."""
+    spark = SparkSession("Bug011CTAS")
+    try:
+        # Create source table
+        df = spark.createDataFrame(
+            [
+                {"name": "Alice", "age": 30, "dept": "IT"},
+                {"name": "Bob", "age": 25, "dept": "HR"},
+            ]
+        )
+        df.write.mode("overwrite").saveAsTable("employees_ctas")
+
+        # CTAS: create new table from a select query
+        spark.sql(
+            """
+            CREATE TABLE IF NOT EXISTS it_employees_ctas AS
+            SELECT name, age FROM employees_ctas WHERE dept = 'IT'
+            """
+        )
+
+        result = spark.sql("SELECT * FROM it_employees_ctas")
+        rows = result.collect()
+
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Alice"
+        assert rows[0]["age"] == 30
+    finally:
+        spark.sql("DROP TABLE IF EXISTS employees_ctas")
+        spark.sql("DROP TABLE IF EXISTS it_employees_ctas")
+        spark.stop()
+
+


### PR DESCRIPTION
BUG-011 reported failures when using CREATE TABLE ... AS SELECT. Current behavior now passes the DDL parity test (tests/parity/sql/test_ddl.py::TestSQLDDLParity::test_create_table_with_select); this PR adds a unit-level regression test that:\n\n- Creates a source table employees_ctas and runs a CTAS statement into it_employees_ctas.\n- Asserts that the resulting table exists and contains the expected rows and schema (name, age).\n\nThis guards CTAS behavior going forward and documents the supported pattern for creating tables from queries.