### PR TITLE
Add BUG-013 SQL UPDATE regression test

### DIFF
--- a/tests/unit/session/test_sql_update.py
+++ b/tests/unit/session/test_sql_update.py
@@ -1,0 +1,29 @@
+from sparkless.sql import SparkSession
+
+
+def test_update_table_basic() -> None:
+    """BUG-013 regression: UPDATE should modify rows and persist changes."""
+    spark = SparkSession("Bug013Update")
+    try:
+        # Create source table
+        data = [("Alice", 25), ("Bob", 30)]
+        df = spark.createDataFrame(data, ["name", "age"])
+        df.write.mode("overwrite").saveAsTable("update_test")
+
+        # Perform UPDATE via SQL
+        spark.sql("UPDATE update_test SET age = 26 WHERE name = 'Alice'")
+
+        # Verify changes are persisted
+        result = spark.sql("SELECT name, age FROM update_test ORDER BY name")
+        rows = result.collect()
+
+        assert len(rows) == 2
+        assert rows[0]["name"] == "Alice"
+        assert rows[0]["age"] == 26
+        assert rows[1]["name"] == "Bob"
+        assert rows[1]["age"] == 30
+    finally:
+        spark.sql("DROP TABLE IF EXISTS update_test")
+        spark.stop()
+
+


### PR DESCRIPTION
BUG-013 reported issues with SQL UPDATE statements not persisting changes. Current behavior passes the DML parity test (tests/parity/sql/test_dml.py::TestSQLDMLParity::test_update_table); this PR adds a unit-level regression test that:\n\n- Creates a simple table update_test and executes UPDATE update_test SET age = 26 WHERE name = 'Alice'.\n- Verifies that only Alice's row is updated and Bob's row remains unchanged.\n\nThis guards UPDATE behavior going forward and documents the supported pattern for data modification via SQL in sparkless.