### PR TITLE
Fix docs example tests for Sparkless-branded output (BUG-58)

### DIFF
--- a/tests/documentation/test_examples.py
+++ b/tests/documentation/test_examples.py
@@ -112,8 +112,9 @@ class TestExampleScripts:
             env=env,
         )
         assert result.returncode == 0, f"basic_usage.py failed: {result.stderr}"
-        assert "Mock Spark" in result.stdout
+        # Header should mention Sparkless basic usage example
         assert "Basic Usage Example" in result.stdout
+        assert "Sparkless" in result.stdout
 
     @pytest.mark.skipif(
         os.environ.get("MOCK_SPARK_TEST_BACKEND") == "pyspark",
@@ -162,4 +163,5 @@ class TestExampleScripts:
 
         # Verify outputs contain expected content
         basic_output = (outputs_dir / "basic_usage_output.txt").read_text()
-        assert "Mock Spark" in basic_output
+        # Basic usage output should start with the Sparkless-branded header
+        assert "Sparkless - Basic Usage Example" in basic_output


### PR DESCRIPTION
Fixes #58.

- Update `test_basic_usage_runs` to assert that stdout contains both "Basic Usage Example" and "Sparkless", matching the current example branding.
- Update `test_example_outputs_captured` to assert that `basic_usage_output.txt` contains the Sparkless-branded header ("Sparkless - Basic Usage Example").
- Keeps tests focused on stable, high-level content while allowing rich formatting/emojis in the examples.