### PR TITLE
Fix SQL INNER JOIN parity (issue #65)

### DIFF
--- a/sparkless/session/sql/parser.py
+++ b/sparkless/session/sql/parser.py
@@ -428,11 +428,12 @@ class SQLParser:
                 components["select_columns"] = columns
 
         # Extract FROM tables (handle aliases and JOINs)
-        # Pattern: FROM table [alias] [JOIN table2 [alias2] ON condition]
+        # Pattern: FROM table [alias] [INNER|LEFT|RIGHT|FULL]? JOIN table2 [alias2] ON condition]
+        # The join condition should capture until WHERE, GROUP BY, ORDER BY, LIMIT, or end of query
         from_match = re.search(
-            r"FROM\s+(\w+)(?:\s+(\w+))?(?:\s+JOIN\s+(\w+)(?:\s+(\w+))?(?:\s+ON\s+(.+?))?)?",
+            r"FROM\s+(\w+)(?:\s+(\w+))?(?:\s+(?:INNER|LEFT|RIGHT|FULL\s+OUTER)?\s+JOIN\s+(\w+)(?:\s+(\w+))?(?:\s+ON\s+((?:(?!\s+(?:WHERE|GROUP\s+BY|ORDER\s+BY|LIMIT|$)).)+))?)?",
             query,
-            re.IGNORECASE,
+            re.IGNORECASE | re.DOTALL,
         )
         if from_match:
             table1 = from_match.group(1)


### PR DESCRIPTION
This PR fixes the SQL INNER JOIN parity issue where joins were returning incorrect row counts and column values.

**Changes:**
- Updated SQL parser to recognize `INNER JOIN`, `LEFT JOIN`, etc. (was only matching `JOIN`)
- Fixed join condition parsing to capture the full ON clause (was stopping at first word)
- Fixed alias-to-table mapping in join condition evaluation
- Renamed columns during join with table alias prefix to avoid conflicts (e.g., `e_name`, `d_name`)
- Updated column selection to handle table-prefixed columns after join
- Removed local `DataFrame` imports that caused variable shadowing errors

**Test:**
```
pytest tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_inner_join
```

Now passes: returns 2 rows (Alice, Bob) with correct `dept_name` values (IT, HR) instead of 3 rows with wrong values.

Fixes #65