### PR TITLE
Fix SQL filtered SELECT parity (issue #67)

### DIFF
--- a/tests/parity/sql/test_queries.py
+++ b/tests/parity/sql/test_queries.py
@@ -33,7 +33,7 @@ class TestSQLQueriesParity(ParityTestBase):
         df = spark.createDataFrame(expected["input_data"])
         df.write.mode("overwrite").saveAsTable("test_table")
         
-        result = spark.sql("SELECT * FROM test_table WHERE age > 25")
+        result = spark.sql("SELECT * FROM test_table WHERE age > 30")
         
         self.assert_parity(result, expected)
 


### PR DESCRIPTION
This PR fixes the SQL filtered SELECT parity issue.

**Changes:**
- Fixed test query to match expected output: changed `WHERE age > 25` to `WHERE age > 30`
- The expected output was for `age > 30` (1 row: Charlie), but the test was using `age > 25` (2 rows: Bob, Charlie)

**Test:**
```
pytest tests/parity/sql/test_queries.py::TestSQLQueriesParity::test_filtered_select
```

Now passes: returns 1 row (Charlie) with age > 30, matching PySpark parity.

Fixes #67