### PR TITLE
Fix SQL LEFT JOIN implementation (issue #77)

### DIFF
--- a/sparkless/session/sql/executor.py
+++ b/sparkless/session/sql/executor.py
@@ -241,22 +241,26 @@ class SQLExecutor:
                                 df2_join_col = f"{table2_alias}_{df2_col}"
                                 
                                 # Perform join with renamed columns
+                                # Get join type from join_info (default to "inner" if not specified)
+                                join_type = join_info.get("type", "inner")
                                 join_col = df1_renamed[df1_join_col] == df2_renamed[df2_join_col]
-                                df = cast("DataFrame", df1_renamed.join(df2_renamed, join_col, "inner"))  # type: ignore[arg-type]
+                                df = cast("DataFrame", df1_renamed.join(df2_renamed, join_col, join_type))  # type: ignore[arg-type]
                             else:
                                 # Fallback: try direct column names (assume col1 is from df1, col2 from df2)
+                                join_type = join_info.get("type", "inner")
                                 if col1 in df1.columns and col2 in df2.columns:
                                     join_col = df1[col1] == df2[col2]
-                                    df = cast("DataFrame", df1.join(df2, join_col, "inner"))  # type: ignore[arg-type]
+                                    df = cast("DataFrame", df1.join(df2, join_col, join_type))  # type: ignore[arg-type]
                                 elif col2 in df1.columns and col1 in df2.columns:
                                     # Try reverse mapping
                                     join_col = df1[col2] == df2[col1]
-                                    df = cast("DataFrame", df1.join(df2, join_col, "inner"))  # type: ignore[arg-type]
+                                    df = cast("DataFrame", df1.join(df2, join_col, join_type))  # type: ignore[arg-type]
                                 else:
                                     # Last resort: cross join
                                     df = cast("DataFrame", df1.crossJoin(cast("SupportsDataFrameOps", df2)))
                         else:
                             # Fallback: try to join on common column names
+                            join_type = join_info.get("type", "inner")
                             common_cols = set(df1.columns) & set(df2.columns)
                             if common_cols:
                                 join_col_name = list(common_cols)[0]
@@ -268,7 +272,7 @@ class SQLExecutor:
                                     df1.join(
                                         cast("SupportsDataFrameOps", df2),
                                         join_condition,  # type: ignore[arg-type]
-                                        "inner",
+                                        join_type,
                                     ),
                                 )
                             else:

--- a/sparkless/session/sql/parser.py
+++ b/sparkless/session/sql/parser.py
@@ -442,6 +442,24 @@ class SQLParser:
             alias2 = from_match.group(4)
             join_condition = from_match.group(5)
 
+            # Extract join type (INNER, LEFT, RIGHT, FULL OUTER)
+            join_type = "inner"  # default
+            join_type_match = re.search(
+                r"(INNER|LEFT|RIGHT|FULL\s+OUTER)\s+JOIN",
+                query,
+                re.IGNORECASE,
+            )
+            if join_type_match:
+                join_type_str = join_type_match.group(1).upper()
+                if "LEFT" in join_type_str:
+                    join_type = "left"
+                elif "RIGHT" in join_type_str:
+                    join_type = "right"
+                elif "FULL" in join_type_str:
+                    join_type = "full"
+                else:
+                    join_type = "inner"
+
             # Store table and alias mappings
             table_aliases = {table1: alias1 or table1}
             if table2:
@@ -451,6 +469,7 @@ class SQLParser:
                         "table": table2,
                         "alias": alias2 or table2,
                         "condition": join_condition.strip() if join_condition else None,
+                        "type": join_type,
                     }
                 ]
 


### PR DESCRIPTION
This PR fixes the LEFT JOIN implementation.

**Changes:**
- Extract join type (INNER, LEFT, RIGHT, FULL OUTER) from SQL query in parser
- Store join type in join_info dictionary
- Use join type in executor instead of hardcoding `"inner"`
- Updated all join fallback cases to use detected join type

**Test:**
```
pytest tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_left_join
```

Now passes: returns 3 rows (Alice, Bob, Charlie with NULL dept) matching PySpark parity.

Fixes #77