### PR TITLE
Fix SQL aggregation test (issue #79)

### DIFF
--- a/tests/parity/sql/test_queries.py
+++ b/tests/parity/sql/test_queries.py
@@ -57,7 +57,9 @@ class TestSQLQueriesParity(ParityTestBase):
         df = spark.createDataFrame(expected["input_data"])
         df.write.mode("overwrite").saveAsTable("test_table")
         
-        result = spark.sql("SELECT department, AVG(salary) as avg_salary, COUNT(*) as count FROM test_table GROUP BY department")
+        # Use the query from expected output: SELECT AVG(salary) as avg_salary FROM employees
+        # This aggregates over all rows (no GROUP BY)
+        result = spark.sql("SELECT AVG(salary) as avg_salary FROM test_table")
         
         self.assert_parity(result, expected)
 


### PR DESCRIPTION
This PR fixes the aggregation test issue.

**Changes:**
- Updated test query to match expected output: `SELECT AVG(salary) as avg_salary FROM test_table`
- Removed `GROUP BY department` (department column doesn't exist in input data)
- Test now aggregates over all rows (no GROUP BY), matching expected output

**Test:**
```
pytest tests/parity/sql/test_queries.py::TestSQLQueriesParity::test_aggregation
```

Now passes: returns 1 row with avg_salary = 60000.0, matching PySpark parity.

Fixes #79