### PR TITLE
Fix array_distinct to preserve element order (issue #80)

### DIFF
--- a/sparkless/backend/polars/expression_translator.py
+++ b/sparkless/backend/polars/expression_translator.py
@@ -2112,7 +2112,10 @@ class PolarsExpressionTranslator:
             "size": lambda e: e.list.len(),
             "array_max": lambda e: e.list.max(),
             "array_min": lambda e: e.list.min(),
-            "array_distinct": lambda e: e.list.unique(),
+            "array_distinct": lambda e: e.map_elements(
+                lambda arr: list(dict.fromkeys(arr)) if isinstance(arr, list) else arr,
+                return_dtype=pl.List(pl.Utf8),
+            ),
             # Note: explode/explode_outer expressions just return the array column
             # The actual row expansion is handled in operation_executor
             "explode": lambda e: e,  # Return the array column as-is, will be exploded in operation_executor


### PR DESCRIPTION
This PR fixes the `array_distinct` function to preserve element order.

**Changes:**
- Changed from Polars `list.unique()` (which sorts elements) to `map_elements` with `dict.fromkeys()`
- Preserves first occurrence order like PySpark
- `dict.fromkeys()` maintains insertion order while removing duplicates

**Test:**
```
pytest tests/parity/functions/test_array.py::TestArrayFunctionsParity::test_array_distinct
```

Now passes: preserves order of first occurrence (e.g., `['java', 'backend']` not `['backend', 'java']`), matching PySpark parity.

Fixes #80