### PR TITLE
Fix ColumnOperation expression translation (Fixes #88, #90, #92, #93, #95)

### DIFF
--- a/sparkless/backend/polars/expression_translator.py
+++ b/sparkless/backend/polars/expression_translator.py
@@ -65,10 +65,10 @@ class PolarsExpressionTranslator:
             if cached is not None:
                 return cached
 
-        if isinstance(expr, Column):
-            result = self._translate_column(expr)
-        elif isinstance(expr, ColumnOperation):
+        if isinstance(expr, ColumnOperation):
             result = self._translate_operation(expr)
+        elif isinstance(expr, Column):
+            result = self._translate_column(expr)
         elif isinstance(expr, Literal):
             result = self._translate_literal(expr)
         elif isinstance(expr, AggregateFunction):


### PR DESCRIPTION
## Problem

ColumnOperation expressions were being treated as column names instead of being properly translated to Polars expressions. This was because ColumnOperation inherits from Column, so the isinstance check for Column was matching first and calling _translate_column() instead of _translate_operation().

## Solution

Changed the order of isinstance checks in translate() to check for ColumnOperation before Column, ensuring ColumnOperation expressions are properly translated.

## Tests

- ✅ test_notebooks.py::test_quickstart
- ✅ test_column_availability.py
- ✅ parity/dataframe/test_transformations.py::test_with_column
- ✅ parity/functions/test_string.py::test_string_upper
- ✅ parity/functions/test_math.py::test_math_abs
- ✅ ruff format, ruff check, mypy all pass

## Related Issues

Fixes #88, #90, #92, #93, #95