### PR TITLE
Fix test_nanvl to use F.lit(0)

### DIFF
--- a/tests/parity/functions/test_null_handling.py
+++ b/tests/parity/functions/test_null_handling.py
@@ -80,5 +80,5 @@ class TestNullHandlingFunctionsParity(ParityTestBase):
         F = imports.F
         expected = self.load_expected("functions", "nanvl")
         df = spark.createDataFrame(expected["input_data"])
-        result = df.select(F.nanvl(df.salary, 0))
+        result = df.select(F.nanvl(df.salary, F.lit(0)))
         self.assert_parity(result, expected)


### PR DESCRIPTION
## Problem

test_nanvl was using `F.nanvl(df.salary, 0)` but PySpark requires the second argument to be a Column or str, not a raw int.

## Solution

Changed to use `F.lit(0)` instead, which matches PySpark's API requirements.

## Validation

- ✅ Test now passes in PySpark mode
- ✅ Test still fails in mock mode (expected - this is a sparkless bug to be fixed separately)