### PR TITLE
fix: String/Array function fixes - fixes #99, #100, #101

### DIFF
--- a/tests/parity/functions/test_array.py
+++ b/tests/parity/functions/test_array.py
@@ -4,10 +4,8 @@ PySpark parity tests for array functions.
 Tests validate that Sparkless array functions behave identically to PySpark.
 """
 
-import pytest
 
 from tests.fixtures.parity_base import ParityTestBase
-from tests.fixtures.spark_backend import get_backend_type, BackendType
 from tests.fixtures.spark_imports import get_spark_imports
 
 
@@ -75,10 +73,6 @@ class TestArrayFunctionsParity(ParityTestBase):
         )
         self.assert_parity(result, expected)
 
-    @pytest.mark.skipif(
-        get_backend_type() == BackendType.MOCK,
-        reason="Skipped in mock mode - array_join returns None instead of joined string. See issue #100",
-    )
     def test_array_join(self, spark):
         """Test array_join function matches PySpark behavior."""
         imports = get_spark_imports()
@@ -97,10 +91,6 @@ class TestArrayFunctionsParity(ParityTestBase):
         result = df.select(F.array_union(df.arr1, df.arr2))
         self.assert_parity(result, expected)
 
-    @pytest.mark.skipif(
-        get_backend_type() == BackendType.MOCK,
-        reason="Skipped in mock mode - array_sort returns None instead of sorted array. See issue #101",
-    )
     def test_array_sort(self, spark):
         """Test array_sort function matches PySpark behavior."""
         imports = get_spark_imports()

--- a/tests/parity/functions/test_string.py
+++ b/tests/parity/functions/test_string.py
@@ -4,10 +4,8 @@ PySpark parity tests for string functions.
 Tests validate that Sparkless string functions behave identically to PySpark.
 """
 
-import pytest
 
 from tests.fixtures.parity_base import ParityTestBase
-from tests.fixtures.spark_backend import get_backend_type, BackendType
 from tests.fixtures.spark_imports import get_spark_imports
 
 
@@ -176,10 +174,6 @@ class TestStringFunctionsParity(ParityTestBase):
         result = df.select(F.base64(df.name))
         self.assert_parity(result, expected)
 
-    @pytest.mark.skipif(
-        get_backend_type() == BackendType.MOCK,
-        reason="Skipped in mock mode - initcap function not implemented in Polars expression translator. See issue #99",
-    )
     def test_initcap(self, spark):
         """Test initcap function matches PySpark behavior."""
         imports = get_spark_imports()


### PR DESCRIPTION
Fixes #99, #100, #101

## Changes
- Add `initcap` function to function_map in expression_translator.py with Polars `to_titlecase()` implementation
- Fix `array_join` to return joined string using Polars `list.join()` method
- Fix `array_sort` to return sorted array using Polars `list.sort()` method with proper descending parameter handling
- Unskipped related tests: test_initcap, test_array_join, test_array_sort

## Testing
- All three tests now pass: test_initcap, test_array_join, test_array_sort
- Code quality checks pass: ruff format, ruff check, mypy
- No regressions in existing tests

## Issues Fixed
- #99: initcap function not implemented in Polars expression translator
- #100: array_join function returns None instead of joined string
- #101: array_sort function returns None instead of sorted array