### PR TITLE
Fix #108 and #109: Combined ColumnOperation expressions with & and | operators

### DIFF
--- a/sparkless/backend/polars/expression_translator.py
+++ b/sparkless/backend/polars/expression_translator.py
@@ -149,10 +149,11 @@ class PolarsExpressionTranslator:
         value = op.value
 
         # Translate left side
-        if isinstance(column, Column):
-            left = pl.col(column.name)
-        elif isinstance(column, ColumnOperation):
+        # Check ColumnOperation before Column since ColumnOperation is a subclass of Column
+        if isinstance(column, ColumnOperation):
             left = self._translate_operation(column)
+        elif isinstance(column, Column):
+            left = pl.col(column.name)
         elif isinstance(column, Literal):
             # Resolve lazy literals before translating
             if hasattr(column, "_is_lazy") and column._is_lazy:
@@ -339,10 +340,11 @@ class PolarsExpressionTranslator:
                 raise ValueError(f"Unsupported unary operation: {operation}")
 
         # Translate right side
-        if isinstance(value, Column):
-            right = pl.col(value.name)
-        elif isinstance(value, ColumnOperation):
+        # Check ColumnOperation before Column since ColumnOperation is a subclass of Column
+        if isinstance(value, ColumnOperation):
             right = self._translate_operation(value)
+        elif isinstance(value, Column):
+            right = pl.col(value.name)
         elif isinstance(value, Literal):
             # Resolve lazy literals before translating
             if hasattr(value, "_is_lazy") and value._is_lazy:


### PR DESCRIPTION
## Summary

Fixes issues #108 and #109 where combined `ColumnOperation` expressions using the `&` (AND) and `|` (OR) operators were incorrectly treated as column names in `DataFrame.filter()` instead of being evaluated as filter expressions.

## Root Cause

The issue was in `sparkless/backend/polars/expression_translator.py` where the `isinstance` checks were in the wrong order. Since `ColumnOperation` is a subclass of `Column`, checking `isinstance(column, Column)` first would match `ColumnOperation` instances, causing them to be treated as simple column references using `pl.col(column.name)` instead of being recursively translated.

## Changes

- Fixed the isinstance check order in `_translate_operation` method to check `ColumnOperation` before `Column` for both the left side (`column`) and right side (`value`) translations.

## Testing

- Verified the fix works with the exact reproduction cases from issues #108 and #109
- All existing tests pass (228 passed)
- Quality checks pass (ruff format, ruff check, mypy)

## Example

```python
from sparkless import SparkSession, functions as F

spark = SparkSession('test')
df = spark.createDataFrame(
    [{'a': 1, 'b': 2}, {'a': None, 'b': 3}, {'a': 5, 'b': 0}],
    'a int, b int'
)

expr1 = F.col('a').isNotNull()
expr2 = F.col('b') > 0

# This now works correctly
result = df.filter(expr1 & expr2)  # No more ColumnNotFoundError
result = df.filter(expr1 | expr2)  # No more ColumnNotFoundError
```

Fixes #108
Fixes #109