### PR TITLE
Fix #112: Table data not visible after append write

### DIFF
--- a/sparkless/backend/polars/storage.py
+++ b/sparkless/backend/polars/storage.py
@@ -237,6 +237,10 @@ class PolarsSchema:
         Returns:
             PolarsTable instance
         """
+        # If table already exists, return existing instance to avoid overwriting data
+        if table in self.tables:
+            return self.tables[table]
+
         schema = StructType(columns) if isinstance(columns, list) else columns
 
         polars_table = PolarsTable(

--- a/tests/parity/dataframe/test_table_append_persistence.py
+++ b/tests/parity/dataframe/test_table_append_persistence.py
@@ -1,0 +1,100 @@
+"""Test table append persistence - ensures data is visible after append writes.
+
+Tests fix for issue #112: Table data not visible after append write.
+"""
+
+from tests.fixtures.parity_base import ParityTestBase
+
+
+class TestTableAppendPersistence(ParityTestBase):
+    """Test that table data is immediately visible after append writes."""
+
+    def test_append_data_visible_immediately(self, spark):
+        """Test that data appended to a table is immediately visible.
+
+        This test verifies the fix for issue #112 where data written with
+        append mode was not immediately visible when querying the table.
+        """
+        # Create schema
+        spark.sql("CREATE SCHEMA IF NOT EXISTS test_schema")
+
+        # Create table with initial data
+        data1 = [{"id": 1, "name": "test1"}]
+        df1 = spark.createDataFrame(data1, "id int, name string")
+        df1.write.mode("overwrite").saveAsTable("test_schema.test_table")
+
+        # Verify initial data
+        result1 = spark.table("test_schema.test_table")
+        assert result1.count() == 1, "Initial table should have 1 row"
+
+        # Append more data
+        data2 = [{"id": 2, "name": "test2"}]
+        df2 = spark.createDataFrame(data2, "id int, name string")
+        df2.write.mode("append").saveAsTable("test_schema.test_table")
+
+        # Verify appended data is immediately visible
+        result2 = spark.table("test_schema.test_table")
+        count = result2.count()
+        assert count == 2, (
+            f"Table should have 2 rows after append, got {count}. "
+            "This verifies fix for issue #112."
+        )
+
+        # Verify all data is present
+        rows = result2.collect()
+        assert len(rows) == 2
+        assert rows[0]["id"] in [1, 2]
+        assert rows[1]["id"] in [1, 2]
+        assert {row["id"] for row in rows} == {1, 2}
+
+    def test_append_to_new_table(self, spark):
+        """Test that appending to a non-existent table creates it correctly."""
+        # Create schema
+        spark.sql("CREATE SCHEMA IF NOT EXISTS test_schema")
+
+        # Append to non-existent table (should create it)
+        data1 = [{"id": 1, "name": "test1"}]
+        df1 = spark.createDataFrame(data1, "id int, name string")
+        df1.write.mode("append").saveAsTable("test_schema.new_table")
+
+        # Verify data is immediately visible
+        result = spark.table("test_schema.new_table")
+        assert result.count() == 1, "New table created by append should have 1 row"
+
+        # Append more data
+        data2 = [{"id": 2, "name": "test2"}]
+        df2 = spark.createDataFrame(data2, "id int, name string")
+        df2.write.mode("append").saveAsTable("test_schema.new_table")
+
+        # Verify all data is visible
+        result2 = spark.table("test_schema.new_table")
+        assert result2.count() == 2, "Table should have 2 rows after second append"
+
+    def test_multiple_append_operations(self, spark):
+        """Test that multiple append operations preserve all data."""
+        # Create schema
+        spark.sql("CREATE SCHEMA IF NOT EXISTS test_schema")
+
+        # Create initial table
+        data1 = [{"id": 1, "value": "a"}]
+        df1 = spark.createDataFrame(data1, "id int, value string")
+        df1.write.mode("overwrite").saveAsTable("test_schema.multi_append")
+
+        # Perform multiple append operations
+        for i in range(2, 6):
+            data = [{"id": i, "value": chr(ord("a") + i - 1)}]
+            df = spark.createDataFrame(data, "id int, value string")
+            df.write.mode("append").saveAsTable("test_schema.multi_append")
+
+            # Verify data is visible after each append
+            result = spark.table("test_schema.multi_append")
+            assert result.count() == i, (
+                f"After {i - 1} appends, table should have {i} rows, got {result.count()}"
+            )
+
+        # Final verification
+        result = spark.table("test_schema.multi_append")
+        assert result.count() == 5, "Final table should have 5 rows"
+        rows = result.collect()
+        ids = {row["id"] for row in rows}
+        assert ids == {1, 2, 3, 4, 5}, "All rows should be present"


### PR DESCRIPTION
## Summary

Fixes issue #112 where data written to tables using append mode was not immediately visible when querying the table.

## Root Cause

The issue was in `PolarsSchema.create_table()` which would overwrite existing table instances without checking if the table already existed. When a new `PolarsTable` instance was created, it would initialize with an empty DataFrame and load from parquet (if available), potentially losing in-memory data that hadn't been written to disk yet.

## Changes

- Modified `PolarsSchema.create_table()` to check if a table already exists and return the existing instance instead of creating a new one
- Added comprehensive tests in `tests/parity/dataframe/test_table_append_persistence.py` to verify:
  - Data appended to existing tables is immediately visible
  - Data appended to new tables (created during append) is immediately visible  
  - Multiple append operations preserve all data

## Testing

- All existing tests pass (49 passed)
- New tests verify the fix works correctly
- Quality checks pass (ruff format, ruff check, mypy)

Fixes #112