### PR TITLE
Fix issue #122: DataFrame.filter() returns 0 rows on tables with complex schemas

### DIFF
--- a/sparkless/core/condition_evaluator.py
+++ b/sparkless/core/condition_evaluator.py
@@ -43,11 +43,13 @@ class ConditionEvaluator:
         Returns:
             True if condition is met, False otherwise.
         """
-        if isinstance(condition, Column):
-            return row.get(condition.name) is not None
-
+        # Check ColumnOperation BEFORE Column since ColumnOperation is a subclass of Column
+        # This ensures comparison operations (==, !=, etc.) are properly evaluated
         if isinstance(condition, ColumnOperation):
             return ConditionEvaluator._evaluate_column_operation(row, condition)
+
+        if isinstance(condition, Column):
+            return row.get(condition.name) is not None
 
         # For simple values, check if truthy
         return bool(condition) if condition is not None else False

--- a/tests/parity/dataframe/test_filter.py
+++ b/tests/parity/dataframe/test_filter.py
@@ -75,3 +75,192 @@ class TestFilterParity(ParityTestBase):
         assert result.count() == 3, (
             "Should return 3 rows where at least one condition is true"
         )
+
+    def test_filter_on_table_with_complex_schema(self, spark):
+        """Test filter on DataFrames read from tables with complex schemas.
+
+        Tests fix for issue #122: DataFrame.filter() returns 0 rows on tables
+        created with saveAsTable() using complex schemas (29+ fields).
+
+        The bug was that ColumnOperation is a subclass of Column, so isinstance()
+        checks for Column before ColumnOperation incorrectly handled comparison
+        operations as simple column existence checks.
+        """
+        from sparkless.spark_types import (
+            StructType,
+            StructField,
+            StringType,
+            TimestampType,
+            FloatType,
+            IntegerType,
+        )
+        from datetime import datetime
+
+        imports = get_spark_imports()
+        F = imports.F
+
+        # Create schema
+        schema_name = "test_schema"
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
+
+        # Create DataFrame with complex schema (29 fields)
+        complex_schema = StructType(
+            [
+                StructField("run_id", StringType(), False),
+                StructField("run_mode", StringType(), False),
+                StructField("run_started_at", TimestampType(), True),
+                StructField("run_ended_at", TimestampType(), True),
+                StructField("execution_id", StringType(), False),
+                StructField("pipeline_id", StringType(), False),
+                StructField("schema", StringType(), False),
+                StructField("phase", StringType(), False),
+                StructField("step_name", StringType(), False),
+                StructField("step_type", StringType(), False),
+                StructField("start_time", TimestampType(), True),
+                StructField("end_time", TimestampType(), True),
+                StructField("duration_secs", FloatType(), False),
+                StructField("table_fqn", StringType(), True),
+                StructField("write_mode", StringType(), True),
+                StructField("input_rows", IntegerType(), True),
+                StructField("output_rows", IntegerType(), True),
+                StructField("rows_written", IntegerType(), True),
+                StructField("rows_processed", IntegerType(), True),
+                StructField("table_total_rows", IntegerType(), True),
+                StructField("valid_rows", IntegerType(), True),
+                StructField("invalid_rows", IntegerType(), True),
+                StructField("validation_rate", FloatType(), True),
+                StructField("success", StringType(), False),
+                StructField("error_message", StringType(), True),
+                StructField("memory_usage_mb", FloatType(), True),
+                StructField("cpu_usage_percent", FloatType(), True),
+                StructField("metadata", StringType(), True),
+                StructField("created_at", StringType(), True),
+            ]
+        )
+
+        current_time = datetime.now()
+        data = [
+            (
+                "initial_run_1",
+                "initial",
+                current_time,
+                current_time,
+                "exec_1",
+                "pipeline_1",
+                schema_name,
+                "bronze",
+                "step_1",
+                "transform",
+                current_time,
+                current_time,
+                30.0,
+                None,
+                None,
+                100,
+                100,
+                100,
+                100,
+                None,
+                100,
+                0,
+                100.0,
+                "true",
+                None,
+                None,
+                None,
+                "{}",
+                current_time.isoformat(),
+            ),
+            (
+                "initial_run_1",
+                "initial",
+                current_time,
+                current_time,
+                "exec_2",
+                "pipeline_1",
+                schema_name,
+                "silver",
+                "step_2",
+                "transform",
+                current_time,
+                current_time,
+                25.0,
+                None,
+                None,
+                100,
+                100,
+                100,
+                100,
+                None,
+                100,
+                0,
+                100.0,
+                "true",
+                None,
+                None,
+                None,
+                "{}",
+                current_time.isoformat(),
+            ),
+            (
+                "other_run",
+                "initial",
+                current_time,
+                current_time,
+                "exec_3",
+                "pipeline_1",
+                schema_name,
+                "gold",
+                "step_3",
+                "transform",
+                current_time,
+                current_time,
+                20.0,
+                None,
+                None,
+                100,
+                100,
+                100,
+                100,
+                None,
+                100,
+                0,
+                100.0,
+                "true",
+                None,
+                None,
+                None,
+                "{}",
+                current_time.isoformat(),
+            ),
+        ]
+
+        df = spark.createDataFrame(data, complex_schema)
+        assert df.count() == 3, "Original DataFrame should have 3 rows"
+
+        # Write to table using Delta format
+        table_fqn = f"{schema_name}.test_table"
+        df.write.format("delta").mode("overwrite").option(
+            "overwriteSchema", "true"
+        ).saveAsTable(table_fqn)
+
+        # Read back
+        read_df = spark.table(table_fqn)
+        assert read_df.count() == 3, "Table read should return 3 rows"
+
+        # Try to filter - this was failing before the fix
+        filtered = read_df.filter(read_df.run_id == "initial_run_1")
+        assert filtered.count() == 2, (
+            "Filter should return 2 rows with run_id='initial_run_1'"
+        )
+
+        # Also test with F.col()
+        filtered2 = read_df.filter(F.col("run_id") == "initial_run_1")
+        assert filtered2.count() == 2, "Filter with F.col() should return 2 rows"
+
+        # Verify the filtered rows have the correct run_id
+        filtered_rows = filtered.collect()
+        for row in filtered_rows:
+            assert row.run_id == "initial_run_1", (
+                "All filtered rows should have run_id='initial_run_1'"
+            )


### PR DESCRIPTION
## Summary

Fixes issue #122 where `DataFrame.filter()` returned 0 rows when filtering DataFrames read from tables created with `saveAsTable()` using complex schemas (29+ fields).

## Root Cause

The bug was in `ConditionEvaluator.evaluate_condition()` where `ColumnOperation` was checked AFTER `Column`. Since `ColumnOperation` is a subclass of `Column`, `isinstance(condition, Column)` returned `True` for `ColumnOperation` objects, causing comparison operations (==, !=, etc.) to be incorrectly handled as simple column existence checks instead of actual comparisons.

## Fix

Check `ColumnOperation` BEFORE `Column` in the isinstance chain to ensure comparison operations are properly evaluated.

## Changes

- Fixed `ConditionEvaluator.evaluate_condition()` to check `ColumnOperation` before `Column`
- Added comprehensive test case `test_filter_on_table_with_complex_schema()` that tests filtering DataFrames read from tables with complex schemas

## Testing

- ✅ All existing tests pass
- ✅ New test case passes
- ✅ Ruff format and check pass
- ✅ Test suite passes (no regressions)

Fixes #122