### PR TITLE
Fix to_timestamp() to accept multiple input types for PySpark compatibility

### DIFF
--- a/tests/test_to_timestamp_compatibility.py
+++ b/tests/test_to_timestamp_compatibility.py
@@ -1,0 +1,173 @@
+"""
+Tests for to_timestamp() compatibility with multiple input types.
+
+This test suite verifies that to_timestamp() accepts all input types
+that PySpark supports, matching PySpark's behavior exactly.
+
+Issue #131: to_timestamp() should accept TimestampType input for PySpark compatibility
+"""
+
+import pytest
+from sparkless import SparkSession, functions as F
+from datetime import datetime, date
+from sparkless.spark_types import (
+    IntegerType,
+    LongType,
+    DateType,
+    DoubleType,
+    StructType,
+    StructField,
+)
+
+
+class TestToTimestampCompatibility:
+    """Test to_timestamp() compatibility with PySpark."""
+
+    def test_to_timestamp_timestamp_type_pass_through(self):
+        """Test that to_timestamp() accepts TimestampType input (pass-through behavior).
+
+        This is the exact scenario from issue #131.
+        """
+        spark = SparkSession("test")
+        try:
+            # Create DataFrame with timestamp string
+            data = [("2024-01-01T10:00:00", "test")]
+            df = spark.createDataFrame(data, ["timestamp_str", "name"])
+
+            # Convert to timestamp
+            df = df.withColumn(
+                "ts", F.to_timestamp(df["timestamp_str"], "yyyy-MM-dd'T'HH:mm:ss")
+            )
+
+            # Try to_timestamp on TimestampType column - should work now
+            result = df.withColumn(
+                "ts2", F.to_timestamp(df["ts"], "yyyy-MM-dd'T'HH:mm:ss")
+            )
+
+            # Verify both columns are TimestampType
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+            assert isinstance(rows[0]["ts2"], datetime)
+            # ts2 should be the same as ts (pass-through behavior)
+            assert rows[0]["ts"] == rows[0]["ts2"]
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_string_type_with_format(self):
+        """Test that to_timestamp() works with StringType input and format string."""
+        spark = SparkSession("test")
+        try:
+            data = [("2024-01-01T10:00:00",)]
+            df = spark.createDataFrame(data, ["timestamp_str"])
+
+            result = df.withColumn(
+                "ts", F.to_timestamp(F.col("timestamp_str"), "yyyy-MM-dd'T'HH:mm:ss")
+            )
+
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+            assert rows[0]["ts"] == datetime(2024, 1, 1, 10, 0, 0)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_string_type_without_format(self):
+        """Test that to_timestamp() works with StringType input without format."""
+        spark = SparkSession("test")
+        try:
+            data = [("2024-01-01 10:00:00",)]
+            df = spark.createDataFrame(data, ["timestamp_str"])
+
+            result = df.withColumn("ts", F.to_timestamp(F.col("timestamp_str")))
+
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_integer_type_unix_timestamp(self):
+        """Test that to_timestamp() accepts IntegerType input (Unix timestamp in seconds)."""
+        spark = SparkSession("test")
+        try:
+            # Unix timestamp for 2024-01-01 10:00:00 UTC
+            unix_ts = 1704110400
+            schema = StructType([StructField("unix_ts", IntegerType(), True)])
+            df = spark.createDataFrame([{"unix_ts": unix_ts}], schema=schema)
+
+            result = df.withColumn("ts", F.to_timestamp(F.col("unix_ts")))
+
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_long_type_unix_timestamp(self):
+        """Test that to_timestamp() accepts LongType input (Unix timestamp in seconds)."""
+        spark = SparkSession("test")
+        try:
+            # Unix timestamp for 2024-01-01 10:00:00 UTC
+            unix_ts = 1704110400
+            schema = StructType([StructField("unix_ts", LongType(), True)])
+            df = spark.createDataFrame([{"unix_ts": unix_ts}], schema=schema)
+
+            result = df.withColumn("ts", F.to_timestamp(F.col("unix_ts")))
+
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_date_type_conversion(self):
+        """Test that to_timestamp() accepts DateType input (converts Date to Timestamp)."""
+        spark = SparkSession("test")
+        try:
+            schema = StructType([StructField("date_col", DateType(), True)])
+            df = spark.createDataFrame([{"date_col": date(2024, 1, 1)}], schema=schema)
+
+            result = df.withColumn("ts", F.to_timestamp(F.col("date_col")))
+
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+            # Date should be converted to timestamp at midnight
+            assert rows[0]["ts"].date() == date(2024, 1, 1)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_double_type_unix_timestamp(self):
+        """Test that to_timestamp() accepts DoubleType input (Unix timestamp with decimal seconds)."""
+        spark = SparkSession("test")
+        try:
+            # Unix timestamp with decimals for 2024-01-01 10:00:00.5 UTC
+            unix_ts = 1704110400.5
+            schema = StructType([StructField("unix_ts", DoubleType(), True)])
+            df = spark.createDataFrame([{"unix_ts": unix_ts}], schema=schema)
+
+            result = df.withColumn("ts", F.to_timestamp(F.col("unix_ts")))
+
+            rows = result.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["ts"], datetime)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_rejects_unsupported_type(self):
+        """Test that to_timestamp() rejects unsupported input types."""
+        spark = SparkSession("test")
+        try:
+            from sparkless.spark_types import BooleanType
+
+            schema = StructType([StructField("bool_col", BooleanType(), True)])
+            df = spark.createDataFrame([{"bool_col": True}], schema=schema)
+
+            with pytest.raises(
+                TypeError,
+                match="requires StringType, TimestampType, IntegerType, LongType, DateType, or DoubleType",
+            ):
+                df.withColumn("ts", F.to_timestamp(F.col("bool_col")))
+        finally:
+            spark.stop()

--- a/tests/test_type_strictness.py
+++ b/tests/test_type_strictness.py
@@ -12,19 +12,107 @@ from sparkless import SparkSession, functions as F
 class TestTypeStrictness:
     """Test strict type checking in functions."""
 
-    def test_to_timestamp_requires_string(self):
-        """Test that to_timestamp requires string or timestamp input."""
+    def test_to_timestamp_accepts_multiple_types(self):
+        """Test that to_timestamp accepts StringType, TimestampType, IntegerType, LongType, DateType, and DoubleType."""
         spark = SparkSession("test")
         try:
-            from sparkless.spark_types import IntegerType, StructType, StructField
+            from sparkless.spark_types import (
+                IntegerType,
+                LongType,
+                DateType,
+                DoubleType,
+                StructType,
+                StructField,
+            )
+            from datetime import datetime, date
 
-            # Create DataFrame with explicit IntegerType schema (not string or timestamp)
-            schema = StructType([StructField("date", IntegerType(), True)])
-            df = spark.createDataFrame([{"date": 12345}], schema=schema)
+            # Test StringType input
+            df_str = spark.createDataFrame(
+                [{"date_str": "2023-01-01 12:00:00"}], schema=["date_str"]
+            )
+            result_str = df_str.withColumn("parsed", F.to_timestamp(F.col("date_str")))
+            assert result_str is not None
+            rows = result_str.collect()
+            assert len(rows) == 1
+            assert isinstance(rows[0]["parsed"], datetime)
 
-            # This should fail - to_timestamp requires StringType input
-            with pytest.raises(TypeError, match="requires StringType input"):
-                df.withColumn("parsed", F.to_timestamp(F.col("date")))
+            # Test TimestampType input (pass-through)
+            df_ts = spark.createDataFrame(
+                [{"ts": datetime(2023, 1, 1, 12, 0, 0)}], schema=["ts"]
+            )
+            result_ts = df_ts.withColumn("ts2", F.to_timestamp(F.col("ts")))
+            assert result_ts is not None
+            rows_ts = result_ts.collect()
+            assert len(rows_ts) == 1
+            assert isinstance(rows_ts[0]["ts2"], datetime)
+
+            # Test IntegerType input (Unix timestamp)
+            schema_int = StructType([StructField("unix_ts", IntegerType(), True)])
+            df_int = spark.createDataFrame(
+                [{"unix_ts": 1672574400}], schema=schema_int
+            )  # 2023-01-01 12:00:00 UTC
+            result_int = df_int.withColumn("parsed", F.to_timestamp(F.col("unix_ts")))
+            assert result_int is not None
+            rows_int = result_int.collect()
+            assert len(rows_int) == 1
+            assert isinstance(rows_int[0]["parsed"], datetime)
+
+            # Test LongType input (Unix timestamp)
+            schema_long = StructType([StructField("unix_ts", LongType(), True)])
+            df_long = spark.createDataFrame(
+                [{"unix_ts": 1672574400}], schema=schema_long
+            )
+            result_long = df_long.withColumn("parsed", F.to_timestamp(F.col("unix_ts")))
+            assert result_long is not None
+            rows_long = result_long.collect()
+            assert len(rows_long) == 1
+            assert isinstance(rows_long[0]["parsed"], datetime)
+
+            # Test DateType input
+            schema_date = StructType([StructField("date_col", DateType(), True)])
+            df_date = spark.createDataFrame(
+                [{"date_col": date(2023, 1, 1)}], schema=schema_date
+            )
+            result_date = df_date.withColumn(
+                "parsed", F.to_timestamp(F.col("date_col"))
+            )
+            assert result_date is not None
+            rows_date = result_date.collect()
+            assert len(rows_date) == 1
+            assert isinstance(rows_date[0]["parsed"], datetime)
+
+            # Test DoubleType input (Unix timestamp with decimals)
+            schema_double = StructType([StructField("unix_ts", DoubleType(), True)])
+            df_double = spark.createDataFrame(
+                [{"unix_ts": 1672574400.5}], schema=schema_double
+            )
+            result_double = df_double.withColumn(
+                "parsed", F.to_timestamp(F.col("unix_ts"))
+            )
+            assert result_double is not None
+            rows_double = result_double.collect()
+            assert len(rows_double) == 1
+            assert isinstance(rows_double[0]["parsed"], datetime)
+
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_rejects_unsupported_types(self):
+        """Test that to_timestamp rejects unsupported input types."""
+        spark = SparkSession("test")
+        try:
+            from sparkless.spark_types import BooleanType, StructType, StructField
+
+            # Create DataFrame with BooleanType (not supported)
+            schema = StructType([StructField("bool_col", BooleanType(), True)])
+            df = spark.createDataFrame([{"bool_col": True}], schema=schema)
+
+            # This should fail - BooleanType is not supported
+            with pytest.raises(
+                TypeError,
+                match="requires StringType, TimestampType, IntegerType, LongType, DateType, or DoubleType",
+            ):
+                df.withColumn("parsed", F.to_timestamp(F.col("bool_col")))
         finally:
             spark.stop()
 


### PR DESCRIPTION
## Description

This PR fixes issue #131 by updating `to_timestamp()` to accept multiple input types, matching PySpark's behavior.

## Changes

- **Updated `to_timestamp()` function**: Now accepts `StringType`, `TimestampType`, `IntegerType`, `LongType`, `DateType`, and `DoubleType` inputs
- **Polars backend**: Modified to use `map_elements` UDF for type-aware conversion, avoiding `SchemaError` when processing non-string types
- **Type validation**: Updated validation in both `DataFrame` and `DateTimeFunctions` to reflect expanded supported types
- **Tests**: Added comprehensive test suite (`test_to_timestamp_compatibility.py`) covering all supported input types
- **Code quality**: Fixed all mypy errors (unreachable statements, redundant casts, unused type ignore comments)

## Behavior

- **StringType**: Parses with format string (or default formats if no format provided)
- **TimestampType**: Pass-through (returns as-is, matching PySpark)
- **IntegerType/LongType**: Treated as Unix timestamp in seconds
- **DateType**: Converts Date to Timestamp
- **DoubleType**: Treated as Unix timestamp with decimal seconds

## Testing

- All existing tests pass (263 tests)
- New comprehensive test suite for `to_timestamp()` compatibility
- All mypy type checks pass
- All ruff linting/formatting checks pass

Fixes #131