### PR TITLE
Fix issue 156: Improve error message for dropped columns in select

### DIFF
--- a/sparkless/core/exceptions/operation.py
+++ b/sparkless/core/exceptions/operation.py
@@ -151,7 +151,8 @@ class SparkColumnNotFoundError(SparkException, AttributeError):
         if custom_message:
             msg = custom_message
         else:
-            msg = f"'DataFrame' object has no attribute '{column_name}'. Available columns: {', '.join(available_columns)}"
+            # Use PySpark-style error message format
+            msg = f"cannot resolve '{column_name}' given input columns: [{', '.join(available_columns)}]"
         super().__init__(msg)
 
 

--- a/tests/test_issue_156_select_dropped_column.py
+++ b/tests/test_issue_156_select_dropped_column.py
@@ -1,0 +1,69 @@
+"""
+Test for issue #156: select() uses attribute access for dropped columns, causing AttributeError.
+
+This test reproduces the bug where selecting a dropped column raises AttributeError
+instead of a proper "column not found" error.
+"""
+
+import pytest
+from sparkless import SparkSession, functions as F
+from sparkless.core.exceptions.operation import SparkColumnNotFoundError
+
+
+def test_select_dropped_column_raises_proper_error():
+    """Test that selecting a dropped column raises SparkColumnNotFoundError, not AttributeError."""
+    spark = SparkSession.builder.appName("test").getOrCreate()
+
+    # Create DataFrame with column
+    data = [("imp_001", "2024-01-15T10:30:45.123456", "campaign_1")]
+    df = spark.createDataFrame(
+        data, ["impression_id", "impression_date", "campaign_id"]
+    )
+
+    # Apply transform that drops the column
+    df_transformed = (
+        df.withColumn(
+            "impression_date_parsed",
+            F.to_timestamp(
+                F.regexp_replace(F.col("impression_date"), r"\.\d+", "").cast("string"),
+                "yyyy-MM-dd'T'HH:mm:ss",
+            ),
+        )
+        .select(
+            "impression_id",
+            "campaign_id",
+            "impression_date_parsed",  # New column, original 'impression_date' is dropped
+        )
+    )
+
+    # Verify column is dropped
+    assert "impression_date" not in df_transformed.columns
+    assert "impression_date_parsed" in df_transformed.columns
+
+    # THE BUG: select() should raise SparkColumnNotFoundError, not AttributeError
+    with pytest.raises(SparkColumnNotFoundError) as exc_info:
+        df_transformed.select("impression_date")
+
+    # Verify the error message is appropriate
+    assert "impression_date" in str(exc_info.value)
+    assert "impression_id" in str(exc_info.value) or "campaign_id" in str(exc_info.value)
+
+
+def test_select_dropped_column_minimal_repro():
+    """Minimal reproduction of the bug."""
+    spark = SparkSession.builder.appName("minimal_repro").getOrCreate()
+
+    # Create DataFrame
+    df = spark.createDataFrame([("a", "b")], ["col1", "col2"])
+
+    # Drop column via select
+    df_dropped = df.select("col1")
+
+    # Try to select dropped column - should raise SparkColumnNotFoundError, not AttributeError
+    with pytest.raises(SparkColumnNotFoundError) as exc_info:
+        df_dropped.select("col2")
+
+    # Verify the error message
+    assert "col2" in str(exc_info.value)
+    assert "col1" in str(exc_info.value)
+


### PR DESCRIPTION
This PR fixes issue #156 where select() was raising an error with a misleading message that implied attribute access was used.

Changes:
- Changed SparkColumnNotFoundError message format from 'DataFrame' object has no attribute column_name to PySpark-style cannot resolve column_name given input columns: [...]
- This makes the error message clearer and doesn't imply attribute access was used
- Added tests to verify the fix

Fixes #156