### PR TITLE
Fix issue #169: Handle df_materialized in drop operation after to_timestamp()

### DIFF
--- a/sparkless/backend/polars/materializer.py
+++ b/sparkless/backend/polars/materializer.py
@@ -651,7 +651,14 @@ class PolarsMaterializer:
                 # This ensures dependent columns are preserved even if dependency graph is incomplete
                 if current_op_index + 1 < len(optimized_operations):
                     # Collect current state to materialize all columns
-                    df_collected = lazy_df.collect()
+                    # Use materialized DataFrame if available, otherwise collect from lazy
+                    if df_materialized is not None:
+                        df_collected = df_materialized
+                        df_materialized = None  # Clear after use
+                    elif lazy_df is not None:
+                        df_collected = lazy_df.collect()
+                    else:
+                        raise ValueError("No DataFrame available for drop operation")
 
                     # Drop columns using select to preserve schema correctly
                     # Using select instead of drop ensures schema is properly maintained
@@ -715,7 +722,14 @@ class PolarsMaterializer:
                         df_materialized = None
                 elif columns_to_preserve:
                     # No future operations but we have columns to preserve
-                    df_collected = lazy_df.collect()
+                    # Use materialized DataFrame if available, otherwise collect from lazy
+                    if df_materialized is not None:
+                        df_collected = df_materialized
+                        df_materialized = None  # Clear after use
+                    elif lazy_df is not None:
+                        df_collected = lazy_df.collect()
+                    else:
+                        raise ValueError("No DataFrame available for drop operation")
                     current_cols = set(df_collected.columns)
                     cols_to_keep = list(current_cols - set(columns_to_drop))
                     if not cols_to_keep:
@@ -728,7 +742,14 @@ class PolarsMaterializer:
                 else:
                     # No dependencies and no future operations - can drop directly
                     # But we still need to handle non-existent columns and all-columns case
-                    df_collected = lazy_df.collect()
+                    # Use materialized DataFrame if available, otherwise collect from lazy
+                    if df_materialized is not None:
+                        df_collected = df_materialized
+                        df_materialized = None  # Clear after use
+                    elif lazy_df is not None:
+                        df_collected = lazy_df.collect()
+                    else:
+                        raise ValueError("No DataFrame available for drop operation")
                     cols_to_keep = [
                         col
                         for col in df_collected.columns

--- a/tests/test_issue_169_to_timestamp_drop_error.py
+++ b/tests/test_issue_169_to_timestamp_drop_error.py
@@ -1,0 +1,165 @@
+"""
+Test for issue #169: 'NoneType' object has no attribute 'collect' after transform with to_timestamp().
+
+This test reproduces the exact scenario from issue #169 where:
+1. A DataFrame is created with timestamp strings
+2. regexp_replace is used to clean the timestamp
+3. to_timestamp() is applied in a withColumn
+4. The intermediate column is dropped
+5. The DataFrame is materialized (count/collect)
+
+The bug occurred because the drop operation didn't check for df_materialized
+before calling lazy_df.collect(), causing an AttributeError when lazy_df was None.
+"""
+
+from sparkless import SparkSession, functions as F
+from datetime import datetime, timedelta
+
+
+class TestIssue169ToTimestampDropError:
+    """Test fix for issue #169: to_timestamp() + drop() + materialize() error."""
+
+    def test_to_timestamp_drop_materialize_basic(self):
+        """Test the basic reproduction case from issue #169."""
+        spark = SparkSession("test_issue_169")
+        try:
+            # Create test data with timestamp strings
+            data = []
+            for i in range(150):
+                data.append(
+                    {
+                        "lab_id": f"LAB-{i:08d}",
+                        "test_date": (
+                            datetime.now() - timedelta(days=i % 365)
+                        ).isoformat(),
+                    }
+                )
+
+            bronze_df = spark.createDataFrame(data, ["lab_id", "test_date"])
+
+            # Transform with to_timestamp() - this is the exact scenario from issue #169
+            silver_df = (
+                bronze_df.withColumn(
+                    "test_date_clean",
+                    F.regexp_replace(F.col("test_date"), r"\.\d+", ""),
+                )
+                .withColumn(
+                    "test_date_parsed",
+                    F.to_timestamp(F.col("test_date_clean"), "yyyy-MM-dd'T'HH:mm:ss"),
+                )
+                .drop("test_date_clean")
+                .select("lab_id", "test_date_parsed")
+            )
+
+            # Materialize (THIS WAS FAILING BEFORE THE FIX)
+            count = silver_df.count()
+            assert count == 150
+
+            # Verify the data is correct
+            rows = silver_df.collect()
+            assert len(rows) == 150
+            for row in rows:
+                assert "lab_id" in row
+                assert "test_date_parsed" in row
+                assert isinstance(row["test_date_parsed"], datetime)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_drop_multiple_columns(self):
+        """Test to_timestamp() followed by dropping multiple columns."""
+        spark = SparkSession("test_issue_169_multiple_drops")
+        try:
+            data = [
+                {
+                    "id": 1,
+                    "timestamp_str": "2024-01-01T10:00:00",
+                    "extra_col": "test",
+                },
+                {
+                    "id": 2,
+                    "timestamp_str": "2024-01-02T11:00:00",
+                    "extra_col": "test2",
+                },
+            ]
+
+            df = spark.createDataFrame(data)
+
+            result = (
+                df.withColumn(
+                    "ts_clean",
+                    F.regexp_replace(F.col("timestamp_str"), r"\.\d+", ""),
+                )
+                .withColumn(
+                    "timestamp",
+                    F.to_timestamp(F.col("ts_clean"), "yyyy-MM-dd'T'HH:mm:ss"),
+                )
+                .drop("ts_clean", "extra_col")
+                .select("id", "timestamp")
+            )
+
+            # Materialize - should work now
+            count = result.count()
+            assert count == 2
+
+            rows = result.collect()
+            assert len(rows) == 2
+            for row in rows:
+                assert isinstance(row["timestamp"], datetime)
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_drop_with_select(self):
+        """Test to_timestamp() + drop() + select() chain."""
+        spark = SparkSession("test_issue_169_select")
+        try:
+            data = [
+                {"id": 1, "ts_str": "2024-01-01T10:00:00"},
+                {"id": 2, "ts_str": "2024-01-02T11:00:00"},
+            ]
+
+            df = spark.createDataFrame(data)
+
+            result = (
+                df.withColumn(
+                    "ts_clean", F.regexp_replace(F.col("ts_str"), r"\.\d+", "")
+                )
+                .withColumn(
+                    "ts", F.to_timestamp(F.col("ts_clean"), "yyyy-MM-dd'T'HH:mm:ss")
+                )
+                .drop("ts_clean")
+                .select("id", "ts")
+            )
+
+            # Materialize - should work
+            rows = result.collect()
+            assert len(rows) == 2
+        finally:
+            spark.stop()
+
+    def test_to_timestamp_drop_with_filter(self):
+        """Test to_timestamp() + drop() + filter() chain."""
+        spark = SparkSession("test_issue_169_filter")
+        try:
+            data = [
+                {"id": 1, "ts_str": "2024-01-01T10:00:00"},
+                {"id": 2, "ts_str": "2024-01-02T11:00:00"},
+            ]
+
+            df = spark.createDataFrame(data)
+
+            result = (
+                df.withColumn(
+                    "ts_clean", F.regexp_replace(F.col("ts_str"), r"\.\d+", "")
+                )
+                .withColumn(
+                    "ts", F.to_timestamp(F.col("ts_clean"), "yyyy-MM-dd'T'HH:mm:ss")
+                )
+                .drop("ts_clean")
+                .filter(F.col("id") > 1)
+            )
+
+            # Materialize - should work
+            count = result.count()
+            assert count == 1
+        finally:
+            spark.stop()


### PR DESCRIPTION
## Summary

Fixes issue #169 where `to_timestamp()` followed by `drop()` causes `'NoneType' object has no attribute 'collect'` error.

## Problem

When `to_timestamp()` is used in a `withColumn` operation, the code sets `lazy_df = None` and stores the result in `df_materialized`. However, the `drop` operation tried to call `lazy_df.collect()` without checking if `lazy_df` was `None` or if `df_materialized` was available.

## Solution

Updated the `drop` operation handling in `sparkless/backend/polars/materializer.py` to check for `df_materialized` first (similar to how `select` and `withColumn` operations handle it), and only call `lazy_df.collect()` if `lazy_df` is not `None`.

## Changes

- Fixed three locations in drop operation where `lazy_df.collect()` was called without checking:
  1. Main materialization path (line ~654)
  2. Columns to preserve path (line ~718)  
  3. No dependencies path (line ~731)

- Added comprehensive test suite (`tests/test_issue_169_to_timestamp_drop_error.py`) with 4 test cases covering:
  - Basic reproduction case
  - Multiple column drops
  - Drop with select
  - Drop with filter

## Testing

- ✅ All 4 new tests passing
- ✅ All 457 existing tests still passing
- ✅ No regressions introduced
- ✅ Ruff format and check passing
- ✅ Mypy type checking passing (384 files)

## Verification

The reproduction script from issue #169 now completes successfully:
```python
# This now works without errors
silver_df = (
    bronze_df.withColumn("test_date_clean", F.regexp_replace(...))
    .withColumn("test_date_parsed", F.to_timestamp(...))
    .drop("test_date_clean")
    .select("lab_id", "test_date_parsed")
)
count = silver_df.count()  # ✅ No longer throws AttributeError
```

Closes #169