### PR TITLE
Fix issue #201: Correct pytest-xdist import check

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -25,7 +25,7 @@ fi
 echo ""
 
 # Check if pytest-xdist is available for parallel execution
-if python3 -c "import pytest_xdist" 2>/dev/null; then
+if python3 -c "import xdist" 2>/dev/null; then
     # Allow override of worker count via SPARKLESS_TEST_WORKERS, default to 8
     WORKERS="${SPARKLESS_TEST_WORKERS:-8}"
     echo "✅ pytest-xdist available - using parallel execution (${WORKERS} workers)"


### PR DESCRIPTION
## Description
This PR fixes issue #201, where the `run_all_tests.sh` script incorrectly checks for pytest-xdist availability using `import pytest_xdist`, which fails even when pytest-xdist is correctly installed.

## Problem
The script uses `import pytest_xdist` to check if pytest-xdist is available, but this import fails because the package name is `pytest-xdist` while the Python module name is `xdist`.

## Solution
Changed the import check from `import pytest_xdist` to `import xdist` on line 28 of `tests/run_all_tests.sh`.

## Testing
- Verified that `import xdist` correctly detects pytest-xdist installation
- The script now properly detects pytest-xdist and enables parallel execution

Fixes #201