### PR TITLE
Fix CI mypy errors

### DIFF
--- a/sparkless/dataframe/lazy.py
+++ b/sparkless/dataframe/lazy.py
@@ -140,7 +140,7 @@ class LazyEvaluationEngine:
                 from ..functions.core.column import ColumnOperation
 
                 # expr.operation is guaranteed to be a string in ColumnOperation
-                op_str: str = expr.operation
+                op_str: str = cast("str", expr.operation)
                 return ColumnOperation(underlying_expr, op_str, None)
             # Otherwise return original if no match found
             return expr
@@ -159,9 +159,10 @@ class LazyEvaluationEngine:
                 if new_column is not expr.column:
                     # Create new ColumnOperation with replaced column
                     from ..functions.core.column import ColumnOperation
+                    from typing import cast
 
                     # expr.operation is guaranteed to be a string in ColumnOperation
-                    new_op_str: str = expr.operation
+                    new_op_str: str = cast("str", expr.operation)
                     new_op = ColumnOperation(
                         new_column, new_op_str, getattr(expr, "value", None)
                     )
@@ -180,9 +181,10 @@ class LazyEvaluationEngine:
                 if new_value is not expr.value:
                     # Create new ColumnOperation with replaced value
                     from ..functions.core.column import ColumnOperation
+                    from typing import cast
 
                     # expr.operation is guaranteed to be a string in ColumnOperation
-                    new_op_str2: str = expr.operation
+                    new_op_str2: str = cast("str", expr.operation)
                     new_op = ColumnOperation(expr.column, new_op_str2, new_value)
                     # Check if this new expression matches a computed column
                     new_expr_signature = LazyEvaluationEngine._normalize_expression(

--- a/sparkless/dataframe/writer.py
+++ b/sparkless/dataframe/writer.py
@@ -939,11 +939,11 @@ class DataFrameWriter:
             # Verify schema is valid (has fields and is a StructType)
             if schema and isinstance(schema, StructType):
                 if hasattr(schema, "fields") and len(schema.fields) > 0:
-                    return cast("StructType", schema)
+                    return schema
                 elif len(schema.fields) == 0:
                     # Empty schema - this might be valid for empty DataFrames
                     # but we should still return it
-                    return cast("StructType", schema)
+                    return schema
         except Exception:
             # If standard extraction fails, try alternative methods
             logger.debug(
@@ -966,7 +966,7 @@ class DataFrameWriter:
                 and hasattr(materialized.schema, "fields")
                 and len(materialized.schema.fields) > 0
             ):
-                return cast("StructType", materialized.schema)
+                return materialized.schema
         except Exception:
             logger.debug(
                 "Materialization-based schema extraction failed, continuing",
@@ -992,7 +992,7 @@ class DataFrameWriter:
                     and hasattr(inferred_schema, "fields")
                     and len(inferred_schema.fields) > 0
                 ):
-                    return cast("StructType", inferred_schema)
+                    return inferred_schema
         except Exception:
             logger.debug(
                 "Schema inference from sample failed, continuing", exc_info=True


### PR DESCRIPTION
## Description

Fixes mypy errors that were causing CI to fail after merging PR #209.

## Changes

### 1. Fix ColumnOperation.operation type narrowing in lazy.py
- Replace type ignore comments with 
- Mypy doesn't properly narrow the type from Column.operation (None) to ColumnOperation.operation (str)
- Use cast() to tell mypy that we know it's a string when expr is ColumnOperation

### 2. Remove redundant casts in writer.py
- Remove redundant  calls
- We're already type-narrowing with , so the cast is redundant
- Mypy correctly infers the type from isinstance checks

## Testing
- Mypy passes on modified files
- No functional changes