### PR TITLE
Fix #212: DataFrame.select() with list of Column objects

### DIFF
--- a/sparkless/dataframe/services/transformation_service.py
+++ b/sparkless/dataframe/services/transformation_service.py
@@ -66,13 +66,12 @@ class TransformationService:
 
         # PySpark compatibility: if a single list/tuple is passed, unpack it
         # This allows df.select(["col1", "col2"]) to work like df.select("col1", "col2")
+        # Also supports df.select([F.col("col1"), F.col("col2")])
         if (
             len(columns) == 1
             and isinstance(columns[0], (list, tuple))
-            and all(isinstance(col, str) for col in columns[0])
         ):
-            # Only unpack if all elements are strings (column names)
-            # If it contains Column objects or other types, treat as single column
+            # Unpack list/tuple of columns, whether they're strings, Column objects, or mixed
             columns = tuple(columns[0])
 
         # Validate column names eagerly (even in lazy mode) to match PySpark behavior

--- a/tests/test_issue_212_select_with_column_list.py
+++ b/tests/test_issue_212_select_with_column_list.py
@@ -1,0 +1,78 @@
+"""
+Test for Issue #212: DataFrame.select() with list of Column objects.
+
+This test verifies that df.select([psf.col("name"), psf.col("dept")]) works correctly.
+"""
+
+import pytest
+from sparkless.sql import SparkSession
+import sparkless.sql.functions as psf
+
+
+@pytest.fixture
+def spark():
+    """Create a SparkSession for testing."""
+    return SparkSession.builder.appName("Example").getOrCreate()
+
+
+def test_select_with_list_of_column_objects(spark):
+    """Test that select() works with a list of Column objects."""
+    df = spark.createDataFrame([
+        {"name": "Alice", "dept": "IT", "salary": 50000},
+        {"name": "Bob", "dept": "HR", "salary": 60000},
+        {"name": "Charlie", "dept": "IT", "salary": 70000},
+    ])
+
+    # This should work without TypeError
+    columns_to_select = [psf.col("name"), psf.col("dept")]
+    result = df.select(columns_to_select)
+
+    # Verify the result
+    result.show(999)
+    rows = result.collect()
+    
+    assert len(rows) == 3
+    assert "name" in result.columns
+    assert "dept" in result.columns
+    assert "salary" not in result.columns
+    
+    # Verify the data
+    assert rows[0]["name"] == "Alice"
+    assert rows[0]["dept"] == "IT"
+    assert rows[1]["name"] == "Bob"
+    assert rows[1]["dept"] == "HR"
+    assert rows[2]["name"] == "Charlie"
+    assert rows[2]["dept"] == "IT"
+
+
+def test_select_with_list_of_strings(spark):
+    """Test that select() still works with a list of strings (existing functionality)."""
+    df = spark.createDataFrame([
+        {"name": "Alice", "dept": "IT", "salary": 50000},
+        {"name": "Bob", "dept": "HR", "salary": 60000},
+    ])
+
+    # This should still work
+    columns_to_select = ["name", "dept"]
+    result = df.select(columns_to_select)
+
+    assert len(result.collect()) == 2
+    assert "name" in result.columns
+    assert "dept" in result.columns
+
+
+def test_select_with_mixed_list(spark):
+    """Test that select() works with a mixed list of strings and Column objects."""
+    df = spark.createDataFrame([
+        {"name": "Alice", "dept": "IT", "salary": 50000},
+        {"name": "Bob", "dept": "HR", "salary": 60000},
+    ])
+
+    # Mixed list of strings and Column objects
+    columns_to_select = ["name", psf.col("dept")]
+    result = df.select(columns_to_select)
+
+    assert len(result.collect()) == 2
+    assert "name" in result.columns
+    assert "dept" in result.columns
+


### PR DESCRIPTION
## Description
Fixes issue #212: Calling `DataFrame.select()` with a list of `psf.col()` statements raises TypeError.

## Changes
- Updated `select()` method to handle lists containing Column objects, not just strings
- Previously only unpacked lists if all elements were strings
- Now supports `df.select([F.col('name'), F.col('dept')])`
- Maintains backward compatibility with string lists

## Testing
- Added comprehensive tests for Column list, string list, and mixed lists
- All tests pass

## Related Issues
Fixes #212

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix `select()` list handling**
> 
> - Updates `TransformationService.select()` to unpack a single list/tuple of columns regardless of element type (strings, `Column` objects, or mixed), enabling `df.select([F.col("name"), F.col("dept")])` while preserving existing validation and lazy evaluation
> 
> **Tests**
> 
> - Adds `tests/test_issue_212_select_with_column_list.py` with cases for a list of `Column` objects, a list of strings, and a mixed list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a426fc99fb2f383c4d86417725e146ff554dc92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->