### PR TITLE
Fix #215: Row kwargs-style initialization

### DIFF
--- a/sparkless/spark_types.py
+++ b/sparkless/spark_types.py
@@ -665,13 +665,26 @@ class Row:
         {'name': 'Alice', 'age': 25}
     """
 
-    def __init__(self, data: Any, schema: Optional["StructType"] = None):
+    def __init__(self, data: Any = None, schema: Optional["StructType"] = None, **kwargs):
         """Initialize Row.
 
         Args:
             data: Row data. Accepts dict, list of tuples, or sequence-like.
+                  If None and kwargs are provided, kwargs are used as data (PySpark-compatible).
             schema: Optional schema providing ordered field names for index access.
+            **kwargs: Optional keyword arguments for kwargs-style initialization (PySpark-compatible).
+                     Example: Row(Column1="Value1", Column2=2)
+
+        Example:
+            >>> row = Row({"name": "Alice", "age": 25})
+            >>> row = Row(name="Alice", age=25)  # kwargs-style
+            >>> row.name
+            'Alice'
         """
+        # PySpark compatibility: if data is None and kwargs are provided, use kwargs as data
+        if data is None and kwargs:
+            data = kwargs
+        
         self._schema = schema
 
         # Handle list of tuples - preserves duplicate column names

--- a/tests/test_issue_215_row_kwargs_init.py
+++ b/tests/test_issue_215_row_kwargs_init.py
@@ -1,0 +1,117 @@
+"""
+Test for Issue #215: Row kwargs-style initialization.
+
+This test verifies that Row(Column1="Value1", Column2=2) works correctly.
+"""
+
+import pytest
+from sparkless.sql import SparkSession
+from sparkless.sql import Row
+from datetime import date
+
+
+@pytest.fixture
+def spark():
+    """Create a SparkSession for testing."""
+    return SparkSession.builder.appName("Example").getOrCreate()
+
+
+def test_row_kwargs_initialization(spark):
+    """Test that Row supports kwargs-style initialization."""
+    # This should work without TypeError
+    row = Row(
+        Column1="Value1",
+        Column2=2,
+        Column3=3.0,
+        Column4=date(2026, 1, 1)
+    )
+    
+    # Verify the row can be accessed by attribute
+    assert row.Column1 == "Value1"
+    assert row.Column2 == 2
+    assert row.Column3 == 3.0
+    assert row.Column4 == date(2026, 1, 1)
+    
+    # Verify the row can be accessed by key
+    assert row["Column1"] == "Value1"
+    assert row["Column2"] == 2
+    assert row["Column3"] == 3.0
+    assert row["Column4"] == date(2026, 1, 1)
+    
+    # Verify asDict() works
+    row_dict = row.asDict()
+    assert row_dict["Column1"] == "Value1"
+    assert row_dict["Column2"] == 2
+    assert row_dict["Column3"] == 3.0
+    assert row_dict["Column4"] == date(2026, 1, 1)
+
+
+def test_row_kwargs_with_createDataFrame(spark):
+    """Test that Row with kwargs-style initialization works with createDataFrame."""
+    # Create DataFrame using Row with kwargs-style initialization
+    df = spark.createDataFrame(
+        [
+            Row(
+                Column1="Value1",
+                Column2=2,
+                Column3=3.0,
+                Column4=date(2026, 1, 1)
+            )
+        ]
+    )
+    
+    # Verify the DataFrame was created correctly
+    rows = df.collect()
+    assert len(rows) == 1
+    
+    row = rows[0]
+    assert row["Column1"] == "Value1"
+    assert row["Column2"] == 2
+    assert row["Column3"] == 3.0
+    assert row["Column4"] == date(2026, 1, 1)
+    
+    # Verify schema
+    assert "Column1" in df.columns
+    assert "Column2" in df.columns
+    assert "Column3" in df.columns
+    assert "Column4" in df.columns
+    
+    # Verify data types (string, long, double, date)
+    dtypes = df.dtypes
+    type_dict = dict(dtypes)
+    assert type_dict["Column1"] == "string"
+    assert type_dict["Column2"] == "long"
+    assert type_dict["Column3"] == "double"
+    assert type_dict["Column4"] == "date"
+
+
+def test_row_dict_initialization_still_works(spark):
+    """Test that Row with dict initialization still works (backward compatibility)."""
+    # This should still work
+    row = Row({
+        "name": "Alice",
+        "age": 25
+    })
+    
+    assert row["name"] == "Alice"
+    assert row["age"] == 25
+    assert row.name == "Alice"
+    assert row.age == 25
+
+
+def test_row_empty_kwargs(spark):
+    """Test that Row with empty kwargs still works."""
+    # If data is None and kwargs is empty, should handle gracefully
+    # This might raise an error, which is fine
+    with pytest.raises((ValueError, TypeError)):
+        row = Row()
+
+
+def test_row_explicit_none_data_with_kwargs(spark):
+    """Test that Row(data=None, **kwargs) uses kwargs."""
+    # Explicit None with kwargs should use kwargs
+    row = Row(data=None, Column1="Value1", Column2=2)
+    
+    assert row["Column1"] == "Value1"
+    assert row["Column2"] == 2
+


### PR DESCRIPTION
## Description
Fixes issue #215: `sparkless.sql.Row` does not allow kwargs-style initialization like the pyspark API.

## Changes
- Added support for kwargs-style Row initialization
- Previously only supported `data` and `schema` positional parameters
- Now supports `Row(Column1="Value1", Column2=2)` like PySpark
- Maintains backward compatibility with existing data/schema parameters

## Testing
- Added comprehensive tests for kwargs-style initialization
- All tests pass

## Related Issues
Fixes #215

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds PySpark-compatible kwargs-style initialization for `Row` and verifies interoperability.
> 
> - Update `Row.__init__` to accept `**kwargs` and use them when `data=None`, preserving dict/sequence behaviors and `schema` ordering
> - Expand docstring with kwargs examples and attribute/key access expectations
> - Add tests in `tests/test_issue_215_row_kwargs_init.py` covering kwargs init, `createDataFrame` integration, backward compatibility with dict init, empty kwargs error case, and `data=None` with kwargs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4430e64433136489cf07a90945959869311f0e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->