### PR TITLE
Fix #213: createDataFrame().toDF() with single DataType schema

### DIFF
--- a/tests/test_issue_213_createDataFrame_with_single_type.py
+++ b/tests/test_issue_213_createDataFrame_with_single_type.py
@@ -1,0 +1,75 @@
+"""
+Test for Issue #213: createDataFrame().toDF() with single DataType schema.
+
+This test verifies that createDataFrame(date_list, T.DateType()).toDF("dates") works correctly.
+"""
+
+import pytest
+import datetime
+from sparkless.sql import SparkSession
+from sparkless.sql import types as T
+
+
+@pytest.fixture
+def spark():
+    """Create a SparkSession for testing."""
+    return SparkSession.builder.appName("Example").getOrCreate()
+
+
+def test_createDataFrame_with_single_date_type(spark):
+    """Test that createDataFrame with single DateType and toDF() works correctly."""
+    date_list = [
+        datetime.date(2024, 7, 31),
+        datetime.date(2024, 8, 31),
+        datetime.date(2024, 9, 30),
+    ]
+
+    # This should work without PySparkValueError
+    df_dates = spark.createDataFrame(date_list, T.DateType()).toDF("dates")
+    df_dates.show(999)
+
+    # Verify the DataFrame was created correctly
+    rows = df_dates.collect()
+    assert len(rows) == 3
+    
+    # Verify the column name
+    assert "dates" in df_dates.columns
+    assert len(df_dates.columns) == 1
+    
+    # Verify the data
+    assert rows[0]["dates"] == datetime.date(2024, 7, 31)
+    assert rows[1]["dates"] == datetime.date(2024, 8, 31)
+    assert rows[2]["dates"] == datetime.date(2024, 9, 30)
+    
+    # Verify schema
+    assert df_dates.dtypes[0][0] == "dates"
+    assert df_dates.dtypes[0][1] == "date"
+
+
+def test_createDataFrame_with_single_string_type(spark):
+    """Test that createDataFrame with single StringType and toDF() works."""
+    string_list = ["value1", "value2", "value3"]
+    
+    df_strings = spark.createDataFrame(string_list, T.StringType()).toDF("names")
+    
+    rows = df_strings.collect()
+    assert len(rows) == 3
+    assert "names" in df_strings.columns
+    assert rows[0]["names"] == "value1"
+    assert rows[1]["names"] == "value2"
+    assert rows[2]["names"] == "value3"
+
+
+def test_createDataFrame_with_single_integer_type(spark):
+    """Test that createDataFrame with single IntegerType and toDF() works."""
+    int_list = [1, 2, 3]
+    
+    df_ints = spark.createDataFrame(int_list, T.IntegerType()).toDF("numbers")
+    
+    rows = df_ints.collect()
+    assert len(rows) == 3
+    assert "numbers" in df_ints.columns
+    assert rows[0]["numbers"] == 1
+    assert rows[1]["numbers"] == 2
+    assert rows[2]["numbers"] == 3
+


### PR DESCRIPTION
## Description
Fixes issue #213: Calling `createDataFrame()` with `toDF()` syntax raises PySparkValueError when using single DataType schema.

## Changes
- Added handling for single DataType schema parameters (e.g., `DateType()`, `StringType()`)
- Convert single DataType to StructType with "_c0" column name (PySpark convention)
- Handle positional data conversion when single DataType is used
- Now supports `createDataFrame([date1, date2], DateType()).toDF("dates")`

## Testing
- Added comprehensive tests for single DataType schemas
- All tests pass

## Related Issues
Fixes #213

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves schema handling when `createDataFrame` is given a single `DataType`.
> 
> - Converts a lone `DataType` (e.g., `DateType()`) into `StructType([StructField("_c0", ...)])` and maps positional input into `{"_c0": value}` for PySpark compatibility
> - Extends schema type checks to accept `DataType` and preserves conversion from PySpark `StructType`
> - Adds tests covering lists of dates, strings, and integers with `.toDF()` renaming
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19bb8c4f515b26e87b3f207880b301ac7780120c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->