### PR TITLE
Fix #215: Support Row objects in createDataFrame and preserve date types

### DIFF
--- a/sparkless/core/schema_inference.py
+++ b/sparkless/core/schema_inference.py
@@ -27,6 +27,7 @@ from ..spark_types import (
     MapType,
     BinaryType,
     TimestampType,
+    DateType,
     NullType,
 )
 
@@ -170,8 +171,17 @@ class SchemaInferenceEngine:
             # Users must explicitly cast strings to date/timestamp types
             return StringType()
         else:
-            # Check for datetime objects
-            if hasattr(value, "date") and hasattr(value, "time"):
+            # Check for date/datetime objects
+            import datetime as dt_module
+            
+            if isinstance(value, dt_module.date) and not isinstance(value, dt_module.datetime):
+                # Pure date object (not datetime)
+                return DateType()
+            elif isinstance(value, dt_module.datetime):
+                # datetime object
+                return TimestampType()
+            elif hasattr(value, "date") and hasattr(value, "time"):
+                # Other datetime-like objects
                 return TimestampType()
             return StringType()  # Default fallback
 

--- a/sparkless/spark_types.py
+++ b/sparkless/spark_types.py
@@ -113,7 +113,7 @@ class DataType(_DataTypeBase):  # type: ignore[misc,valid-type]
         type_mapping = {
             "StringType": "string",
             "IntegerType": "int",  # Fixed: was "integer", should be "int"
-            "LongType": "bigint",
+            "LongType": "long",  # PySpark uses "long", not "bigint"
             "DoubleType": "double",
             "BooleanType": "boolean",
             "DateType": "date",


### PR DESCRIPTION
## Description
Completes the fix for issue #215 by allowing Row objects created with kwargs-style initialization to be used with `createDataFrame()`, and ensures date objects are properly preserved throughout the pipeline.

## Changes
- **Row object support in createDataFrame**: Convert Row objects to dictionaries early in the DataFrame creation process (PySpark compatibility)
- **Date type inference**: Fix schema inference to properly detect `datetime.date` objects and infer `DateType` instead of `StringType`
- **LongType compatibility**: Fix `LongType.typeName()` to return `"long"` instead of `"bigint"` for PySpark compatibility
- **Date preservation in Polars**: Preserve date/timestamp objects when materializing from Polars by converting date strings back to date objects after `to_dicts()`

## Testing
- All tests in `test_issue_215_row_kwargs_init.py` now pass (5/5)
- The previously failing test `test_row_kwargs_with_createDataFrame` now passes
- Date objects are correctly preserved when creating DataFrames with Row objects

## Related Issues
Completes the fix for issue #215

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves PySpark compatibility and type fidelity across DataFrame creation, schema inference, and Polars materialization.
> 
> - Accepts `Row` objects in `DataFrameFactory.create_dataframe()` by converting to dicts (kwargs-style supported)
> - Schema inference now maps `datetime.date` → `DateType` and `datetime.datetime`/datetime-like → `TimestampType`
> - Polars materializer restores date/timestamp objects after `to_dicts()` to preserve types in output `Row`s
> - `LongType.typeName()` now returns `"long"` (instead of `"bigint"`) for PySpark compatibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 860139c5bd18f736258ed1f24e0f45c53a218243. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->