### PR TITLE
Fix size() and length() functions returning 0 rows

### DIFF
--- a/sparkless/backend/polars/type_mapper.py
+++ b/sparkless/backend/polars/type_mapper.py
@@ -140,6 +140,18 @@ def polars_dtype_to_mock_type(polars_dtype: pl.DataType) -> DataType:
         return ShortType()
     elif polars_dtype == pl.Int8:
         return ByteType()
+    elif polars_dtype == pl.UInt32:
+        # Polars UInt32 from list.len() - convert to IntegerType for PySpark compatibility
+        return IntegerType()
+    elif polars_dtype == pl.UInt64:
+        # Polars UInt64 - convert to LongType for PySpark compatibility
+        return LongType()
+    elif polars_dtype == pl.UInt16:
+        # Polars UInt16 - convert to ShortType for PySpark compatibility
+        return ShortType()
+    elif polars_dtype == pl.UInt8:
+        # Polars UInt8 - convert to ByteType for PySpark compatibility
+        return ByteType()
     elif polars_dtype == pl.Null:
         return NullType()
     else:


### PR DESCRIPTION
## Description\nFixes two test failures where \ and \ functions were returning 0 rows instead of the expected 3 rows.\n\n## Changes\n- **Added \ function translation**: Added \ to the function_map in expression_translator.py with a helper function \ that handles arrays and maps\n- **Fixed \ function**: Updated \ in function_map to cast result to Int64 for PySpark compatibility (Polars str.len_chars() returns UInt32)\n- **Added unsigned integer type support**: Added support for unsigned integer types (UInt32, UInt64, UInt16, UInt8) in type_mapper.py, converting them to signed integer types for PySpark compatibility\n\n## Root Cause\nThe issue was that Polars \ returns \, which wasn't supported in the type mapper, causing a \ during materialization. This error was silently handled, resulting in empty DataFrames (0 rows instead of 3).\n\n## Testing\n- ✅ test_size: Now passes (was 0 rows, now 3 rows)\n- ✅ test_string_length: Now passes (was 0 rows, now 3 rows)\n- All existing tests still pass\n\n## Related Issues\nFixes the failing parity tests:\n- \\n- \