### PR TITLE
Fix list unpacking issues in groupBy, rollup, and cube methods

### DIFF
--- a/sparkless/dataframe/aggregations/operations.py
+++ b/sparkless/dataframe/aggregations/operations.py
@@ -33,6 +33,7 @@ class AggregationOperations(Generic[SupportsDF]):
 
         Args:
             *columns: Column names or Column objects to group by.
+                     Can also accept a list/tuple of column names: df.groupBy(["col1", "col2"])
 
         Returns:
             GroupedData for aggregation operations.
@@ -40,7 +41,18 @@ class AggregationOperations(Generic[SupportsDF]):
         Example:
             >>> df.groupBy("category").count()
             >>> df.groupBy("dept", "year").avg("salary")
+            >>> df.groupBy(["dept", "year"]).count()  # PySpark-compatible: list of column names
         """
+        # PySpark compatibility: if a single list/tuple is passed, unpack it
+        # This allows df.groupBy(["col1", "col2"]) to work like df.groupBy("col1", "col2")
+        # Also supports df.groupBy(df.columns)
+        if (
+            len(columns) == 1
+            and isinstance(columns[0], (list, tuple))
+        ):
+            # Unpack list/tuple of columns
+            columns = tuple(columns[0])
+
         col_names = []
         for col in columns:
             if isinstance(col, Column):
@@ -77,13 +89,24 @@ class AggregationOperations(Generic[SupportsDF]):
 
         Args:
             *columns: Columns to rollup.
+                     Can also accept a list/tuple of column names: df.rollup(["col1", "col2"])
 
         Returns:
             RollupGroupedData for hierarchical grouping.
 
         Example:
             >>> df.rollup("country", "state").sum("sales")
+            >>> df.rollup(["country", "state"]).sum("sales")  # PySpark-compatible: list of column names
         """
+        # PySpark compatibility: if a single list/tuple is passed, unpack it
+        # This allows df.rollup(["col1", "col2"]) to work like df.rollup("col1", "col2")
+        if (
+            len(columns) == 1
+            and isinstance(columns[0], (list, tuple))
+        ):
+            # Unpack list/tuple of columns
+            columns = tuple(columns[0])
+
         col_names = []
         for col in columns:
             if isinstance(col, Column):
@@ -108,13 +131,24 @@ class AggregationOperations(Generic[SupportsDF]):
 
         Args:
             *columns: Columns to cube.
+                     Can also accept a list/tuple of column names: df.cube(["col1", "col2"])
 
         Returns:
             CubeGroupedData for multi-dimensional grouping.
 
         Example:
             >>> df.cube("year", "month").sum("revenue")
+            >>> df.cube(["year", "month"]).sum("revenue")  # PySpark-compatible: list of column names
         """
+        # PySpark compatibility: if a single list/tuple is passed, unpack it
+        # This allows df.cube(["col1", "col2"]) to work like df.cube("col1", "col2")
+        if (
+            len(columns) == 1
+            and isinstance(columns[0], (list, tuple))
+        ):
+            # Unpack list/tuple of columns
+            columns = tuple(columns[0])
+
         col_names = []
         for col in columns:
             if isinstance(col, Column):

--- a/sparkless/dataframe/services/aggregation_service.py
+++ b/sparkless/dataframe/services/aggregation_service.py
@@ -27,6 +27,7 @@ class AggregationService:
 
         Args:
             *columns: Column names or Column objects to group by.
+                     Can also accept a list/tuple of column names: df.groupBy(["col1", "col2"])
 
         Returns:
             GroupedData for aggregation operations.
@@ -34,7 +35,18 @@ class AggregationService:
         Example:
             >>> df.groupBy("category").count()
             >>> df.groupBy("dept", "year").avg("salary")
+            >>> df.groupBy(["dept", "year"]).count()  # PySpark-compatible: list of column names
         """
+        # PySpark compatibility: if a single list/tuple is passed, unpack it
+        # This allows df.groupBy(["col1", "col2"]) to work like df.groupBy("col1", "col2")
+        # Also supports df.groupBy(df.columns)
+        if (
+            len(columns) == 1
+            and isinstance(columns[0], (list, tuple))
+        ):
+            # Unpack list/tuple of columns
+            columns = tuple(columns[0])
+
         col_names = []
         for col in columns:
             if isinstance(col, Column):
@@ -70,13 +82,24 @@ class AggregationService:
 
         Args:
             *columns: Columns to rollup.
+                     Can also accept a list/tuple of column names: df.rollup(["col1", "col2"])
 
         Returns:
             RollupGroupedData for hierarchical grouping.
 
         Example:
             >>> df.rollup("country", "state").sum("sales")
+            >>> df.rollup(["country", "state"]).sum("sales")  # PySpark-compatible: list of column names
         """
+        # PySpark compatibility: if a single list/tuple is passed, unpack it
+        # This allows df.rollup(["col1", "col2"]) to work like df.rollup("col1", "col2")
+        if (
+            len(columns) == 1
+            and isinstance(columns[0], (list, tuple))
+        ):
+            # Unpack list/tuple of columns
+            columns = tuple(columns[0])
+
         col_names = []
         for col in columns:
             if isinstance(col, Column):
@@ -100,13 +123,24 @@ class AggregationService:
 
         Args:
             *columns: Columns to cube.
+                     Can also accept a list/tuple of column names: df.cube(["col1", "col2"])
 
         Returns:
             CubeGroupedData for multi-dimensional grouping.
 
         Example:
             >>> df.cube("year", "month").sum("revenue")
+            >>> df.cube(["year", "month"]).sum("revenue")  # PySpark-compatible: list of column names
         """
+        # PySpark compatibility: if a single list/tuple is passed, unpack it
+        # This allows df.cube(["col1", "col2"]) to work like df.cube("col1", "col2")
+        if (
+            len(columns) == 1
+            and isinstance(columns[0], (list, tuple))
+        ):
+            # Unpack list/tuple of columns
+            columns = tuple(columns[0])
+
         col_names = []
         for col in columns:
             if isinstance(col, Column):

--- a/tests/test_groupby_rollup_cube_with_list.py
+++ b/tests/test_groupby_rollup_cube_with_list.py
@@ -1,0 +1,144 @@
+"""
+Test for list unpacking issues in groupBy, rollup, and cube methods.
+
+This test verifies that df.groupBy(["col1", "col2"]), df.rollup(["col1", "col2"]),
+and df.cube(["col1", "col2"]) work correctly, similar to fixes for issues #212 and #214.
+"""
+
+import pytest
+from sparkless.sql import SparkSession
+
+
+@pytest.fixture
+def spark():
+    """Create a SparkSession for testing."""
+    return SparkSession.builder.appName("test").getOrCreate()
+
+
+@pytest.fixture
+def sample_df(spark):
+    """Create a sample DataFrame for testing."""
+    data = [
+        {"dept": "IT", "year": 2023, "sales": 100},
+        {"dept": "IT", "year": 2024, "sales": 200},
+        {"dept": "HR", "year": 2023, "sales": 150},
+        {"dept": "HR", "year": 2024, "sales": 250},
+    ]
+    return spark.createDataFrame(data)
+
+
+def test_groupBy_with_list(sample_df):
+    """Test that groupBy() works with a list of column names."""
+    # This should work without SparkColumnNotFoundError
+    result = sample_df.groupBy(["dept", "year"]).count()
+    
+    collected = result.collect()
+    assert len(collected) == 4  # 4 combinations: (IT,2023), (IT,2024), (HR,2023), (HR,2024)
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+    
+    # Verify counts are correct
+    counts = [row.asDict() for row in collected]
+    assert {"dept": "IT", "year": 2023, "count": 1} in counts
+    assert {"dept": "IT", "year": 2024, "count": 1} in counts
+    assert {"dept": "HR", "year": 2023, "count": 1} in counts
+    assert {"dept": "HR", "year": 2024, "count": 1} in counts
+
+
+def test_groupBy_with_tuple(sample_df):
+    """Test that groupBy() works with a tuple of column names."""
+    result = sample_df.groupBy(("dept", "year")).count()
+    
+    assert len(result.collect()) == 4
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_groupBy_with_df_columns(sample_df):
+    """Test that groupBy() works with df.columns (a list attribute)."""
+    # This is a common PySpark pattern
+    # Note: sample_df.columns order is ['dept', 'sales', 'year'], so [:2] gives ['dept', 'sales']
+    result = sample_df.groupBy(sample_df.columns[:2]).count()  # First 2 columns: dept and sales
+    
+    collected = result.collect()
+    assert len(collected) == 4  # Should have 4 combinations
+    assert "dept" in result.columns
+    assert "sales" in result.columns  # First 2 columns are dept and sales
+    assert "count" in result.columns
+
+
+def test_groupBy_backward_compatibility(sample_df):
+    """Test that groupBy() still works with individual column arguments."""
+    result = sample_df.groupBy("dept", "year").count()
+    
+    assert len(result.collect()) == 4
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_rollup_with_list(sample_df):
+    """Test that rollup() works with a list of column names."""
+    # This should work without SparkColumnNotFoundError
+    result = sample_df.rollup(["dept", "year"]).count()
+    
+    collected = result.collect()
+    assert len(collected) > 0  # Rollup creates hierarchical groupings
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_rollup_with_tuple(sample_df):
+    """Test that rollup() works with a tuple of column names."""
+    result = sample_df.rollup(("dept", "year")).count()
+    
+    assert len(result.collect()) > 0
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_rollup_backward_compatibility(sample_df):
+    """Test that rollup() still works with individual column arguments."""
+    result = sample_df.rollup("dept", "year").count()
+    
+    assert len(result.collect()) > 0
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_cube_with_list(sample_df):
+    """Test that cube() works with a list of column names."""
+    # This should work without SparkColumnNotFoundError
+    result = sample_df.cube(["dept", "year"]).count()
+    
+    collected = result.collect()
+    assert len(collected) > 0  # Cube creates multi-dimensional groupings
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_cube_with_tuple(sample_df):
+    """Test that cube() works with a tuple of column names."""
+    result = sample_df.cube(("dept", "year")).count()
+    
+    assert len(result.collect()) > 0
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+
+
+def test_cube_backward_compatibility(sample_df):
+    """Test that cube() still works with individual column arguments."""
+    result = sample_df.cube("dept", "year").count()
+    
+    assert len(result.collect()) > 0
+    assert "dept" in result.columns
+    assert "year" in result.columns
+    assert "count" in result.columns
+


### PR DESCRIPTION
## Description
Fixes list unpacking issues in three aggregation methods that don't handle list parameters correctly, similar to issues #212 and #214 where select() and sort() needed list unpacking for PySpark compatibility.

## Issues Fixed

### 1. groupBy() - List Unpacking Issue
- Problem: df.groupBy(["dept", "year"]) failed with SparkColumnNotFoundError
- Fix: Added list unpacking logic to handle list/tuple parameters
- Impact: Now supports common PySpark patterns like df.groupBy(df.columns) or df.groupBy(col_list)

### 2. rollup() - List Unpacking Issue  
- Problem: df.rollup(["dept", "year"]) failed with SparkColumnNotFoundError
- Fix: Added list unpacking logic to handle list/tuple parameters
- Impact: Now supports hierarchical grouping operations with lists

### 3. cube() - List Unpacking Issue
- Problem: df.cube(["dept", "year"]) failed with SparkColumnNotFoundError  
- Fix: Added list unpacking logic to handle list/tuple parameters
- Impact: Now supports multi-dimensional grouping operations with lists

## Changes

- Modified sparkless/dataframe/aggregations/operations.py: Added list unpacking to groupBy(), rollup(), and cube()
- Modified sparkless/dataframe/services/aggregation_service.py: Added same list unpacking logic to service layer
- Added tests/test_groupby_rollup_cube_with_list.py: Comprehensive tests for all three methods

## Implementation Pattern

Uses the same pattern as select() and sort() fixes from issues #212 and #214:
- Checks if a single list/tuple is passed
- Unpacks it to individual column arguments
- Maintains backward compatibility with individual column arguments

## Testing

- All 10 new tests pass
- Backward compatibility verified (existing patterns still work)
- Tests cover: lists, tuples, df.columns pattern, and individual arguments