### PR TITLE
Add support for array_contains() as join condition (Issue #331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,19 @@
 ## 3.27.0 — Unreleased
 
 ### Added
-- **Issue #331** - Added support for `array_contains()` as join condition
+- **Issue #331** (PR #341) - Added support for `array_contains()` as join condition
   - Join operations now support expression-based conditions like `F.array_contains(df1.IDs, df2.ID)`
   - Updated `apply_join()` to accept ColumnOperation with any operation (not just equality)
   - Implemented `_apply_expression_join()` method that performs cross join + filter for expression-based joins
   - Handles column name conflicts by prefixing right DataFrame columns when needed
   - Supports all join types (inner, left, right, outer) with expression conditions
-  - Comprehensive test coverage: 14 unit tests + 3 PySpark parity tests
-  - Edge cases covered: no matches, multiple matches, null arrays, null IDs, column name conflicts, empty DataFrames
-  - Integration scenarios: with select, filter, orderBy, groupBy, chained joins
+  - Comprehensive test coverage: 31 unit tests + 3 PySpark parity tests
+  - Edge cases covered: no matches, multiple matches, null arrays, null IDs, column name conflicts, empty DataFrames, empty arrays, duplicate values, large arrays (100 elements)
+  - Data type variations: integers, strings, floats
+  - Integration scenarios: with select, filter, orderBy, groupBy, window functions, union, distinct, limit, chained joins, nested select, case/when, coalesce, cast operations
+  - Schema verification for join results
   - Fixes `ValueError: Join keys must be column name(s) or a ColumnOperation` error
+  - Backward compatible: regular column-based joins still work
 - **Issue #330** (PR #340) - Fixed struct field selection with alias
   - Struct field extraction now works correctly when combined with alias (e.g., `F.col("StructValue.E1").alias("E1-Extract")`)
   - Updated `PolarsOperationExecutor.apply_select()` to check original column name (`_original_column._name`) for struct field paths when column is aliased

--- a/tests/parity/functions/test_array_contains_join_parity.py
+++ b/tests/parity/functions/test_array_contains_join_parity.py
@@ -32,9 +32,7 @@ class TestArrayContainsJoinParity:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows = result.collect()
 
             assert len(rows) == 2
@@ -71,9 +69,7 @@ class TestArrayContainsJoinParity:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="inner"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
             rows = result.collect()
 
             assert len(rows) == 3
@@ -110,9 +106,7 @@ class TestArrayContainsJoinParity:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows = result.collect()
 
             assert len(rows) == 3

--- a/tests/test_issue_331_array_contains_join.py
+++ b/tests/test_issue_331_array_contains_join.py
@@ -29,9 +29,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows = result.collect()
 
             assert len(rows) == 2
@@ -65,9 +63,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="inner"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
             rows = result.collect()
 
             assert len(rows) == 2
@@ -95,9 +91,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows = result.collect()
 
             assert len(rows) == 3
@@ -126,9 +120,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="inner"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
             rows = result.collect()
 
             assert len(rows) == 3
@@ -160,16 +152,12 @@ class TestIssue331ArrayContainsJoin:
             )
 
             # Inner join with no matches should return empty
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="inner"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
             rows = result.collect()
             assert len(rows) == 0
 
             # Left join with no matches should return left rows with nulls
-            result2 = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result2 = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows2 = result2.collect()
             assert len(rows2) == 1
             assert rows2[0]["Name"] == "Alice"
@@ -195,9 +183,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows = result.collect()
 
             assert len(rows) >= 1
@@ -228,9 +214,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
             rows = result.collect()
 
             # Should have at least one match (ID=3)
@@ -259,9 +243,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="right"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="right")
             rows = result.collect()
 
             # Should include all right rows
@@ -292,9 +274,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="outer"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="outer")
             rows = result.collect()
 
             # Should include matches and unmatched rows from both sides
@@ -323,10 +303,9 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = (
-                df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
-                .select("Name", "Dept")
-            )
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).select("Name", "Dept")
             rows = result.collect()
 
             assert len(rows) == 2
@@ -353,10 +332,9 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = (
-                df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
-                .filter(F.col("Dept") == "A")
-            )
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).filter(F.col("Dept") == "A")
             rows = result.collect()
 
             assert len(rows) == 1
@@ -381,9 +359,7 @@ class TestIssue331ArrayContainsJoin:
                 ]
             )
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="inner"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
             rows = result.collect()
 
             assert len(rows) == 1
@@ -397,7 +373,13 @@ class TestIssue331ArrayContainsJoin:
         """Test array_contains join with empty DataFrames."""
         spark = SparkSession.builder.appName("issue-331").getOrCreate()
         try:
-            from sparkless.spark_types import StructType, StructField, StringType, ArrayType, IntegerType
+            from sparkless.spark_types import (
+                StructType,
+                StructField,
+                StringType,
+                ArrayType,
+                IntegerType,
+            )
 
             schema1 = StructType(
                 [
@@ -415,9 +397,7 @@ class TestIssue331ArrayContainsJoin:
             df1 = spark.createDataFrame([], schema=schema1)
             df2 = spark.createDataFrame([], schema=schema2)
 
-            result = df1.join(
-                df2, on=F.array_contains(df1.IDs, df2.ID), how="inner"
-            )
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
             rows = result.collect()
 
             assert len(rows) == 0
@@ -449,5 +429,532 @@ class TestIssue331ArrayContainsJoin:
             assert len(rows) == 2
             assert rows[0]["Name"] == "Alice"
             assert rows[0]["Dept"] == "A"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_empty_arrays(self):
+        """Test array_contains join with empty arrays."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": []},  # Empty array
+                    {"Name": "Bob", "IDs": [1, 2, 3]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 1},
+                ]
+            )
+
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
+            rows = result.collect()
+
+            assert len(rows) == 2
+            # Alice with empty array should not match
+            alice_row = next(row for row in rows if row["Name"] == "Alice")
+            assert alice_row["Dept"] is None
+            assert alice_row["ID"] is None
+            # Bob should match
+            bob_row = next(row for row in rows if row["Name"] == "Bob")
+            assert bob_row["Dept"] == "A"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_duplicate_values(self):
+        """Test array_contains join with arrays containing duplicate values."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 1, 2, 2, 3]},  # Duplicates
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 1},
+                    {"Dept": "B", "ID": 2},
+                ]
+            )
+
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
+            rows = result.collect()
+
+            assert len(rows) == 2
+            depts = {row["Dept"] for row in rows}
+            assert depts == {"A", "B"}
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_string_arrays(self):
+        """Test array_contains join with string arrays."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Tags": ["python", "spark", "data"]},
+                    {"Name": "Bob", "Tags": ["java", "scala"]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Skill": "Python", "Tag": "python"},
+                    {"Skill": "Java", "Tag": "java"},
+                ]
+            )
+
+            result = df1.join(df2, on=F.array_contains(df1.Tags, df2.Tag), how="left")
+            rows = result.collect()
+
+            assert len(rows) == 2
+            alice_row = next(row for row in rows if row["Name"] == "Alice")
+            assert alice_row["Skill"] == "Python"
+            bob_row = next(row for row in rows if row["Name"] == "Bob")
+            assert bob_row["Skill"] == "Java"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_float_arrays(self):
+        """Test array_contains join with float arrays."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Values": [1.5, 2.5, 3.5]},
+                    {"Name": "Bob", "Values": [4.0, 5.0]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Category": "A", "Value": 2.5},
+                    {"Category": "B", "Value": 5.0},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.Values, df2.Value), how="left"
+            )
+            rows = result.collect()
+
+            assert len(rows) == 2
+            alice_row = next(row for row in rows if row["Name"] == "Alice")
+            assert alice_row["Category"] == "A"
+            bob_row = next(row for row in rows if row["Name"] == "Bob")
+            assert bob_row["Category"] == "B"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_large_arrays(self):
+        """Test array_contains join with large arrays."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            # Create array with 100 elements
+            large_array = list(range(1, 101))
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": large_array},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 50},  # Middle of array
+                    {"Dept": "B", "ID": 1},  # First element
+                    {"Dept": "C", "ID": 100},  # Last element
+                ]
+            )
+
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
+            rows = result.collect()
+
+            assert len(rows) == 3
+            depts = {row["Dept"] for row in rows}
+            assert depts == {"A", "B", "C"}
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_where_clause(self):
+        """Test array_contains join combined with where/filter conditions."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3], "Age": 25},
+                    {"Name": "Bob", "IDs": [4, 5, 6], "Age": 30},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).filter(F.col("Age") > 25)
+            rows = result.collect()
+
+            assert len(rows) == 1
+            assert rows[0]["Name"] == "Bob"
+            assert rows[0]["Dept"] == "B"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_aggregation(self):
+        """Test array_contains join followed by aggregation."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                    {"Name": "Bob", "IDs": [4, 5, 6]},
+                    {"Name": "Charlie", "IDs": [1, 2, 3]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            result = (
+                df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
+                .groupBy("Dept")
+                .agg(F.count("Name").alias("Count"))
+            )
+            rows = result.collect()
+
+            # Should have counts for each dept
+            assert len(rows) >= 1
+            dept_counts = {
+                row["Dept"]: row["Count"] for row in rows if row["Dept"] is not None
+            }
+            assert "A" in dept_counts
+            assert "B" in dept_counts
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_window_functions(self):
+        """Test array_contains join with window functions."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            from sparkless.window import Window
+
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3], "Score": 100},
+                    {"Name": "Bob", "IDs": [4, 5, 6], "Score": 90},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            window = Window.partitionBy("Dept").orderBy(F.col("Score").desc())
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).withColumn("Rank", F.row_number().over(window))
+            rows = result.collect()
+
+            assert len(rows) == 2
+            for row in rows:
+                assert "Rank" in row
+                assert row["Rank"] == 1  # Each dept has one row
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_union(self):
+        """Test array_contains join with union operations."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                ]
+            )
+
+            df3 = spark.createDataFrame(
+                [
+                    {"Name": "Bob", "IDs": [4, 5, 6]},
+                ]
+            )
+
+            result1 = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
+            result2 = df3.join(df2, on=F.array_contains(df3.IDs, df2.ID), how="left")
+            # Use unionByName to handle potential column order differences
+            combined = result1.unionByName(result2, allowMissingColumns=True)
+            rows = combined.collect()
+
+            assert len(rows) == 2
+            names = {row["Name"] for row in rows}
+            assert names == {"Alice", "Bob"}
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_distinct(self):
+        """Test array_contains join with distinct operation."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3], "Value": 10},
+                    {"Name": "Alice", "IDs": [1, 2, 3], "Value": 10},  # Duplicate
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                ]
+            )
+
+            result = (
+                df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
+                .select(
+                    "Name", "Dept", "ID", "Value"
+                )  # Select specific columns to avoid array distinct issues
+                .distinct()
+            )
+            rows = result.collect()
+
+            # Should have only one row after distinct
+            assert len(rows) == 1
+            assert rows[0]["Name"] == "Alice"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_limit(self):
+        """Test array_contains join with limit operation."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                    {"Name": "Bob", "IDs": [4, 5, 6]},
+                    {"Name": "Charlie", "IDs": [7, 8, 9]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).limit(1)
+            rows = result.collect()
+
+            assert len(rows) == 1
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_multiple_conditions_same_df(self):
+        """Test array_contains join where same left row matches multiple right rows."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3, 4, 5]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 1},
+                    {"Dept": "B", "ID": 2},
+                    {"Dept": "C", "ID": 3},
+                    {"Dept": "D", "ID": 4},
+                    {"Dept": "E", "ID": 5},
+                ]
+            )
+
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="inner")
+            rows = result.collect()
+
+            assert len(rows) == 5
+            depts = {row["Dept"] for row in rows}
+            assert depts == {"A", "B", "C", "D", "E"}
+            # All rows should have Alice's name
+            for row in rows:
+                assert row["Name"] == "Alice"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_nested_select(self):
+        """Test array_contains join with nested select expressions."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                    {"Name": "Bob", "IDs": [4, 5, 6]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).select(
+                F.col("Name"),
+                F.col("Dept").alias("Department"),
+                F.col("ID").alias("MatchedID"),
+            )
+            rows = result.collect()
+
+            assert len(rows) == 2
+            assert "Name" in rows[0]
+            assert "Department" in rows[0]
+            assert "MatchedID" in rows[0]
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_case_when(self):
+        """Test array_contains join with case/when expressions."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                    {"Name": "Bob", "IDs": [4, 5, 6]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).withColumn(
+                "Status",
+                F.when(F.col("Dept").isNotNull(), "Matched").otherwise("NoMatch"),
+            )
+            rows = result.collect()
+
+            assert len(rows) == 2
+            for row in rows:
+                assert "Status" in row
+                if row["Dept"] is not None:
+                    assert row["Status"] == "Matched"
+                else:
+                    assert row["Status"] == "NoMatch"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_coalesce(self):
+        """Test array_contains join with coalesce function."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                    {"Name": "Bob", "IDs": [4, 5, 6]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                    {"Dept": "B", "ID": 5},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).withColumn("FinalDept", F.coalesce(F.col("Dept"), F.lit("Unknown")))
+            rows = result.collect()
+
+            assert len(rows) == 2
+            for row in rows:
+                assert "FinalDept" in row
+                assert row["FinalDept"] in ["A", "B", "Unknown"]
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_with_cast(self):
+        """Test array_contains join with cast operations."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            from sparkless.spark_types import StringType
+
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                ]
+            )
+
+            result = df1.join(
+                df2, on=F.array_contains(df1.IDs, df2.ID), how="left"
+            ).withColumn("DeptStr", F.col("Dept").cast(StringType()))
+            rows = result.collect()
+
+            assert len(rows) == 1
+            assert rows[0]["DeptStr"] == "A"
+        finally:
+            spark.stop()
+
+    def test_array_contains_join_schema_verification(self):
+        """Test that array_contains join produces correct schema."""
+        spark = SparkSession.builder.appName("issue-331").getOrCreate()
+        try:
+            df1 = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "IDs": [1, 2, 3]},
+                ]
+            )
+
+            df2 = spark.createDataFrame(
+                [
+                    {"Dept": "A", "ID": 3},
+                ]
+            )
+
+            result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
+
+            schema = result.schema
+            field_names = [field.name for field in schema.fields]
+
+            # Should contain columns from both DataFrames
+            assert "Name" in field_names
+            assert "IDs" in field_names
+            assert "Dept" in field_names
+            assert "ID" in field_names
         finally:
             spark.stop()


### PR DESCRIPTION
## Description

Fixes issue #331: Join operations now support expression-based conditions like `array_contains()`.

## Changes

### Issue #331: Join doesn't support `array_contains()` condition
- Updated join validation to accept expression-based ColumnOperation conditions (not just equality)
- Implemented `_apply_expression_join()` method for expression-based joins
- Performs cross join + filter approach for expression-based join conditions
- Handles column name conflicts by prefixing right DataFrame columns when needed
- Supports all join types (inner, left, right, outer) with expression conditions
- Fixes `ValueError: Join keys must be column name(s) or a ColumnOperation` error

## Implementation Details

- Modified `PolarsOperationExecutor.apply_join()` to detect expression-based conditions
- Added `_apply_expression_join()` method that:
  - Performs cross join to get all row combinations
  - Translates and evaluates the expression condition
  - Filters based on expression result
  - Handles join types appropriately (left/outer include unmatched rows)
- Maps column references when there are name conflicts (prefixes df2 columns)
- Uses Python fallback for complex expressions that Polars can't translate directly

## Test Coverage

- 14 unit tests covering:
  - Basic array_contains join
  - Different join types (inner, left, right, outer)
  - Multiple matches (array contains multiple matching IDs)
  - No matches
  - Null arrays and null IDs
  - Column name conflicts
  - Empty DataFrames
  - Integration with select, filter, orderBy, groupBy, chained joins
  - Backward compatibility (regular column-based joins still work)
- 3 PySpark parity tests confirming behavior matches PySpark

## Related Issues

Closes #331

## Example

```python
from sparkless.sql import SparkSession
import sparkless.sql.functions as F

spark = SparkSession.builder.appName("Example").getOrCreate()

df1 = spark.createDataFrame([
    {"Name": "Alice", "IDs": [1, 2, 3]},
    {"Name": "Bob", "IDs": [4, 5, 6]},
])

df2 = spark.createDataFrame([
    {"Dept": "A", "ID": 3},
    {"Dept": "B", "ID": 5},
])

# Now works with array_contains as join condition
result = df1.join(df2, on=F.array_contains(df1.IDs, df2.ID), how="left")
result.show()
```