### PR TITLE
Fix #359: Add NAHandler.drop() for df.na.drop() (PySpark parity)

### DIFF
--- a/sparkless/dataframe/attribute_handler.py
+++ b/sparkless/dataframe/attribute_handler.py
@@ -53,6 +53,37 @@ class NAHandler:
         """
         return self._df.fillna(value, subset)
 
+    def drop(
+        self,
+        how: str = "any",
+        thresh: Optional[int] = None,
+        subset: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
+    ) -> Any:
+        """Drop rows with null values (PySpark DataFrameNaFunctions.drop).
+
+        Args:
+            how: 'any' to drop if any null in row, 'all' to drop only if all null.
+            thresh: Keep rows with at least this many non-null values.
+            subset: Optional column name(s) to consider. If None, all columns.
+
+        Returns:
+            DataFrame with null rows dropped.
+
+        Example:
+            >>> df.na.drop()  # Drop rows with any null
+            >>> df.na.drop(subset=["Value"])  # Drop rows with null in Value
+            >>> df.na.drop(how="all")  # Drop only rows that are all null
+        """
+        subset_list: Optional[List[str]] = None
+        if subset is not None:
+            if isinstance(subset, str):
+                subset_list = [subset]
+            elif isinstance(subset, tuple):
+                subset_list = list(subset)
+            else:
+                subset_list = subset
+        return self._df.dropna(how, thresh, subset_list)
+
     def replace(
         self,
         to_replace: Union[int, float, str, List[Any], Dict[Any, Any]],

--- a/tests/test_issue_359_na_drop.py
+++ b/tests/test_issue_359_na_drop.py
@@ -1,0 +1,153 @@
+"""
+Tests for issue #359: NAHandler.drop method.
+
+PySpark supports df.na.drop() for dropping rows with null values.
+This test verifies that Sparkless supports the same operation.
+"""
+
+import pytest
+from sparkless.sql import SparkSession
+
+
+class TestIssue359NADrop:
+    """Test NAHandler.drop method (issue #359)."""
+
+    def test_na_drop_with_subset_exact_issue_scenario(self):
+        """Exact scenario from issue #359: drop rows with None in specified column."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Value": 1},
+                    {"Name": "Bob", "Value": None},
+                ]
+            )
+            result = df.na.drop(subset=["Value"])
+            rows = result.collect()
+            assert len(rows) == 1
+            assert rows[0]["Name"] == "Alice"
+            assert rows[0]["Value"] == 1
+        finally:
+            spark.stop()
+
+    def test_na_drop_no_subset_drops_any_null(self):
+        """na.drop() with no subset drops rows with any null (how='any' default)."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Value": 1},
+                    {"Name": "Bob", "Value": None},
+                    {"Name": "Charlie", "Value": 3},
+                ]
+            )
+            result = df.na.drop()
+            rows = result.collect()
+            assert len(rows) == 2
+            names = {r["Name"] for r in rows}
+            assert names == {"Alice", "Charlie"}
+        finally:
+            spark.stop()
+
+    def test_na_drop_subset_as_string(self):
+        """na.drop(subset='Value') with single column as string."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Value": 1},
+                    {"Name": "Bob", "Value": None},
+                ]
+            )
+            result = df.na.drop(subset="Value")
+            rows = result.collect()
+            assert len(rows) == 1
+            assert rows[0]["Name"] == "Alice"
+        finally:
+            spark.stop()
+
+    def test_na_drop_subset_as_tuple(self):
+        """na.drop(subset=(col1, col2)) with tuple of columns."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"a": 1, "b": 2, "c": 3},
+                    {"a": None, "b": 2, "c": 3},
+                    {"a": 1, "b": None, "c": 3},
+                    {"a": 1, "b": 2, "c": None},
+                ]
+            )
+            # Drop rows with null in a or b only
+            result = df.na.drop(subset=("a", "b"))
+            rows = result.collect()
+            assert len(rows) == 2  # rows 1 and 2 have null in a or b
+        finally:
+            spark.stop()
+
+    def test_na_drop_how_all(self):
+        """na.drop(how='all') drops only rows where all values are null."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"a": 1, "b": 2},
+                    {"a": None, "b": 2},
+                    {"a": None, "b": None},
+                ]
+            )
+            result = df.na.drop(how="all")
+            rows = result.collect()
+            assert len(rows) == 2  # third row is all null
+        finally:
+            spark.stop()
+
+    def test_na_drop_thresh(self):
+        """na.drop(thresh=n) keeps rows with at least n non-null values."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"a": 1, "b": 2, "c": 3},
+                    {"a": 1, "b": None, "c": 3},
+                    {"a": None, "b": None, "c": 3},
+                ]
+            )
+            result = df.na.drop(thresh=2)  # keep rows with >= 2 non-null
+            rows = result.collect()
+            assert len(rows) == 2  # third row has only 1 non-null
+        finally:
+            spark.stop()
+
+    def test_na_drop_no_nulls_returns_same(self):
+        """na.drop() on DataFrame with no nulls returns same row count."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Value": 1},
+                    {"Name": "Bob", "Value": 2},
+                ]
+            )
+            result = df.na.drop()
+            rows = result.collect()
+            assert len(rows) == 2
+        finally:
+            spark.stop()
+
+    def test_na_drop_equivalent_to_dropna(self):
+        """na.drop() produces same result as dropna()."""
+        spark = SparkSession.builder.appName("Example").getOrCreate()
+        try:
+            df = spark.createDataFrame(
+                [
+                    {"Name": "Alice", "Value": 1},
+                    {"Name": "Bob", "Value": None},
+                ]
+            )
+            result_na = df.na.drop(subset=["Value"]).collect()
+            result_direct = df.dropna(subset=["Value"]).collect()
+            assert len(result_na) == len(result_direct) == 1
+            assert result_na[0]["Name"] == result_direct[0]["Name"]
+        finally:
+            spark.stop()


### PR DESCRIPTION
## Summary
Fixes #359: `df.na.drop(subset=["Value"])` was raising `AttributeError: 'NAHandler' object has no attribute 'drop'` because `NAHandler` only had `fill` and `replace`, not `drop`.

## Changes
- **sparkless/dataframe/attribute_handler.py**: Added `drop(how='any', thresh=None, subset=None)` to `NAHandler`, delegating to `DataFrame.dropna()`. `subset` accepts `str`, `list`, or `tuple` (normalized to list) for consistency with `fill`/`replace`.
- **tests/test_issue_359_na_drop.py**: New test module with 8 tests covering the exact issue scenario, `how`/`thresh`/`subset` (string/list/tuple), and parity with `dropna()`.

## Testing
`python3 -m pytest tests/test_issue_359_na_drop.py -v` — all 8 tests pass.

Closes #359