### PR TITLE
Fix #369: ~col.isin([int,...]) on string column - type coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.28.6 — 2026-02-02
+
+### Fixed
+- **Issue #369** - `~F.col("Values").isin([20, 30])` on a string column no longer raises Polars `InvalidOperationError: 'is_in' cannot check for List(Int64) values in String data`
+  - Materializer now passes column dtype for filter conditions that are negation of isin (`~col.isin([...])`) so the inner isin receives it
+  - Expression translator passes `input_col_dtype` through when translating nested ColumnOperation so nested isin can coerce the list to the column type (string column → coerce int list to string list)
+  - PySpark supports this comparison; Sparkless now matches by coercing the right-hand list to the column's type
+
+### Added
+- **Issue #369 tests** - `tests/test_issue_369_isin_negation.py` with 4 tests
+  - Negation isin string column + int list (exact scenario), show(), positive isin same types, negation isin string-to-string
+
 ## 3.28.5 — 2026-02-02
 
 ### Fixed

--- a/sparkless/backend/polars/expression_translator.py
+++ b/sparkless/backend/polars/expression_translator.py
@@ -412,9 +412,10 @@ class PolarsExpressionTranslator:
                     "WindowFunction expressions should be handled by OperationExecutor.apply_with_column"
                 )
         elif isinstance(column, ColumnOperation):
+            # Pass input_col_dtype through so nested isin (e.g. ~col.isin([...])) gets it (#369)
             left = self._translate_operation(
                 column,
-                input_col_dtype=None,
+                input_col_dtype=input_col_dtype,
                 available_columns=available_columns,
                 case_sensitive=case_sensitive,
             )

--- a/tests/test_issue_369_isin_negation.py
+++ b/tests/test_issue_369_isin_negation.py
@@ -1,0 +1,74 @@
+"""
+Tests for issue #369: ~F.col("Values").isin([20, 30]) with string column.
+
+PySpark allows is_in checks with negation when column type and list type differ
+(string column vs int list); Polars raises InvalidOperationError without coercion.
+Sparkless now coerces the list to the column type so ~col.isin([...]) works.
+"""
+
+
+class TestIssue369IsinNegation:
+    """Test ~col.isin([...]) with string column and int list (issue #369)."""
+
+    def test_negation_isin_string_column_int_list(self, spark):
+        """Exact scenario from issue #369: filter with ~col.isin([int, int]) on string column."""
+        from tests.fixtures.spark_imports import get_spark_imports
+
+        F = get_spark_imports().F
+        df = spark.createDataFrame(
+            [
+                {"Name": "Alice", "Values": "10"},
+                {"Name": "Bob", "Values": "20"},
+            ]
+        )
+        df = df.filter(~F.col("Values").isin([20, 30]))
+        rows = df.collect()
+        assert len(rows) == 1
+        assert rows[0]["Name"] == "Alice" and rows[0]["Values"] == "10"
+
+    def test_negation_isin_show(self, spark):
+        """Exact issue scenario: filter + show() (issue #369)."""
+        from tests.fixtures.spark_imports import get_spark_imports
+
+        F = get_spark_imports().F
+        df = spark.createDataFrame(
+            [
+                {"Name": "Alice", "Values": "10"},
+                {"Name": "Bob", "Values": "20"},
+            ]
+        )
+        df = df.filter(~F.col("Values").isin([20, 30]))
+        df.show()
+        rows = df.collect()
+        assert len(rows) == 1 and rows[0]["Name"] == "Alice"
+
+    def test_isin_without_negation_string_column_int_list(self, spark):
+        """Positive isin (no ~) with string column and int list also coerces."""
+        from tests.fixtures.spark_imports import get_spark_imports
+
+        F = get_spark_imports().F
+        df = spark.createDataFrame(
+            [
+                {"Name": "Alice", "Values": "10"},
+                {"Name": "Bob", "Values": "20"},
+            ]
+        )
+        df = df.filter(F.col("Values").isin([20, 30]))
+        rows = df.collect()
+        assert len(rows) == 1
+        assert rows[0]["Name"] == "Bob" and rows[0]["Values"] == "20"
+
+    def test_negation_isin_string_to_string(self, spark):
+        """~col.isin([str, str]) on string column (types match) still works."""
+        from tests.fixtures.spark_imports import get_spark_imports
+
+        F = get_spark_imports().F
+        df = spark.createDataFrame(
+            [
+                {"Name": "Alice", "Values": "10"},
+                {"Name": "Bob", "Values": "20"},
+            ]
+        )
+        df = df.filter(~F.col("Values").isin(["20", "30"]))
+        rows = df.collect()
+        assert len(rows) == 1 and rows[0]["Name"] == "Alice"


### PR DESCRIPTION
Closes #369

## Summary
`~F.col("Values").isin([20, 30])` on a string column raised `polars.exceptions.InvalidOperationError: 'is_in' cannot check for List(Int64) values in String data`. PySpark supports this (coerces for comparison). Sparkless now coerces the right-hand list to the column type so the filter works.

## Solution
1. **Materializer**: When the filter condition is a negation of isin (`~col.isin([...])`), extract the column name from the inner isin and set `input_col_dtype` from the lazy DataFrame schema so the translator receives the column type.
2. **Expression translator**: When translating a nested `ColumnOperation`, pass `input_col_dtype` through (instead of `None`) so the inner isin receives it and can coerce the list to the column type (e.g. string column → coerce `[20, 30]` to `["20", "30"]`).

## Example (from issue)
```python
df = spark.createDataFrame([
    {"Name": "Alice", "Values": "10"},
    {"Name": "Bob", "Values": "20"},
])
df = df.filter(~F.col("Values").isin([20, 30]))
df.show()
# Name  Values
# Alice 10
```

## Testing
- 4 new tests in `tests/test_issue_369_isin_negation.py`: negation isin string+int list (exact scenario), show(), positive isin same mix, negation isin string-to-string.
- `pytest tests/test_issue_369_isin_negation.py -v` passes.
- `ruff format`, `ruff check`, `mypy sparkless tests` pass.