### PR TITLE
Fix #431: allow date vs datetime comparison

### DIFF
--- a/sparkless/backend/polars/expression_translator.py
+++ b/sparkless/backend/polars/expression_translator.py
@@ -1155,6 +1155,16 @@ class PolarsExpressionTranslator:
                 right_dt = _to_python_datetime(right_val)
                 return compare_fn(parsed_dt, right_dt)
 
+            # Date vs datetime: coerce date to datetime at midnight (PySpark parity, #431)
+            if _is_date_like(left_val) and _is_datetime_like(right_val):
+                left_dt = datetime.combine(left_val, datetime.min.time())
+                right_dt = _to_python_datetime(right_val)
+                return compare_fn(left_dt, right_dt)
+            elif _is_datetime_like(left_val) and _is_date_like(right_val):
+                left_dt = _to_python_datetime(left_val)
+                right_dt = datetime.combine(right_val, datetime.min.time())
+                return compare_fn(left_dt, right_dt)
+
             # Default comparison (same types or other combinations)
             return compare_fn(left_val, right_val)
 

--- a/tests/test_issue_431_date_datetime_comparison.py
+++ b/tests/test_issue_431_date_datetime_comparison.py
@@ -1,0 +1,79 @@
+"""Test issue #431: date vs datetime comparison must not raise TypeError.
+
+PySpark allows comparing date and datetime columns. Sparkless must coerce
+date to datetime (at midnight) for comparison instead of raising
+TypeError: can't compare datetime.datetime to datetime.date.
+
+https://github.com/eddiethedean/sparkless/issues/431
+"""
+
+import datetime
+
+from tests.fixtures.spark_imports import get_spark_imports
+
+
+def test_date_less_than_datetime(spark, spark_backend):
+    """F.col('Date') < F.col('DateTime') must filter correctly (#431)."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame(
+        [
+            {
+                "Name": "Alice",
+                "DateTime": datetime.datetime(2023, 1, 1, 12, 0, 0),
+                "Date": datetime.date(2024, 1, 1),
+            },
+            {
+                "Name": "Bob",
+                "DateTime": datetime.datetime(2024, 1, 1, 12, 0, 0),
+                "Date": datetime.date(2024, 1, 1),
+            },
+        ]
+    )
+    result = df.filter(F_backend.col("Date") < F_backend.col("DateTime"))
+    rows = result.collect()
+
+    # Alice: Date 2024-01-01 < DateTime 2023-01-01 12:00 -> False (filtered out)
+    # Bob: Date 2024-01-01 < DateTime 2024-01-01 12:00 -> True (kept)
+    assert len(rows) == 1
+    assert rows[0]["Name"] == "Bob"
+    assert rows[0]["Date"] == datetime.date(2024, 1, 1)
+    assert rows[0]["DateTime"] == datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+
+def test_datetime_greater_than_date(spark, spark_backend):
+    """F.col('DateTime') > F.col('Date') must work."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame(
+        [
+            {
+                "dt": datetime.datetime(2024, 6, 15, 10, 0, 0),
+                "d": datetime.date(2024, 1, 1),
+            },
+        ]
+    )
+    result = df.filter(F_backend.col("dt") > F_backend.col("d"))
+    rows = result.collect()
+    assert len(rows) == 1
+
+
+def test_date_eq_datetime(spark, spark_backend):
+    """Date equals datetime at midnight."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame(
+        [
+            {
+                "d": datetime.date(2024, 1, 1),
+                "dt": datetime.datetime(2024, 1, 1, 0, 0, 0),
+            },
+            {
+                "d": datetime.date(2024, 1, 1),
+                "dt": datetime.datetime(2024, 1, 1, 12, 0, 0),
+            },
+        ]
+    )
+    result = df.filter(F_backend.col("d") == F_backend.col("dt"))
+    rows = result.collect()
+    # Date 2024-01-01 == datetime 2024-01-01 00:00:00 -> True
+    # Date 2024-01-01 == datetime 2024-01-01 12:00:00 -> False
+    assert len(rows) == 1
+    assert rows[0]["dt"] == datetime.datetime(2024, 1, 1, 0, 0, 0)


### PR DESCRIPTION
## Description
Fixes https://github.com/eddiethedean/sparkless/issues/431

Sparkless comparison functions raised `TypeError: can't compare datetime.datetime to datetime.date` when comparing date and datetime columns. PySpark supports this by coercing date to datetime at midnight.

## Root cause
`_compare_with_coercion` in expression_translator.py handled date vs string and datetime vs string, but not date vs datetime. Python's comparison operators fail when mixing date and datetime types.

## Changes
- **expression_translator.py**: Add date vs datetime coercion in `_compare_with_coercion` – convert date to datetime at midnight (`datetime.combine(d, datetime.min.time())`) before comparison.
- **test_issue_431_date_datetime_comparison.py**: Regression tests for Date < DateTime, DateTime > Date, and Date == DateTime.

## Testing
```bash
pytest tests/test_issue_431_date_datetime_comparison.py -v
```

Made with [Cursor](https://cursor.com)