### PR TITLE
fix: add REGEXP and RLIKE support to F.expr() SQL parser (#433)

### DIFF
--- a/sparkless/functions/core/sql_expr_parser.py
+++ b/sparkless/functions/core/sql_expr_parser.py
@@ -46,6 +46,8 @@ class SQLExprParser:
         "UPPER",
         "LOWER",
         "SUBSTRING",
+        "REGEXP",
+        "RLIKE",
     }
 
     @staticmethod
@@ -294,6 +296,20 @@ class SQLExprParser:
             from ...functions.string import StringFunctions
 
             return StringFunctions.like(
+                left_expr,  # type: ignore[arg-type]
+                str(pattern_val),
+            )
+
+        # Parse REGEXP / RLIKE: "col REGEXP 'pattern'", "col RLIKE 'pattern'" (Issue #433)
+        regexp_match = re.search(r"\s+(?:REGEXP|RLIKE)\s+", expr, re.IGNORECASE)
+        if regexp_match:
+            left_str = expr[: regexp_match.start()].strip()
+            right_str = expr[regexp_match.end() :].strip()
+            left_expr = SQLExprParser._parse_expression(left_str)
+            pattern_val = SQLExprParser._parse_simple_value(right_str)
+            from ...functions.string import StringFunctions
+
+            return StringFunctions.regexp(
                 left_expr,  # type: ignore[arg-type]
                 str(pattern_val),
             )

--- a/tests/test_issue_433_regexp_in_expr.py
+++ b/tests/test_issue_433_regexp_in_expr.py
@@ -1,0 +1,84 @@
+"""Test issue #433: REGEXP and RLIKE in F.expr().
+
+PySpark supports df.filter(F.expr("Value REGEXP 'sales|tech'")) and RLIKE.
+Sparkless SQLExprParser previously raised ParseException for these expressions.
+Now parses REGEXP and RLIKE in F.expr() for PySpark parity.
+
+https://github.com/eddiethedean/sparkless/issues/433
+"""
+
+from tests.fixtures.spark_imports import get_spark_imports
+
+
+def test_filter_regexp_exact_issue_433(spark, spark_backend):
+    """Exact scenario from issue #433 - Value REGEXP 'sales|tech'."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame(
+        [
+            {"Name": "Alice", "Value": "sales department"},
+            {"Name": "Bob", "Value": "tech department"},
+            {"Name": "Charlie", "Value": "ceo"},
+        ]
+    )
+    df = df.filter(F_backend.expr("Value REGEXP 'sales|tech'"))
+    df.show()
+    rows = df.collect()
+    assert len(rows) == 2
+    names = {r["Name"] for r in rows}
+    assert names == {"Alice", "Bob"}
+
+
+def test_filter_rlike_same_as_regexp(spark, spark_backend):
+    """RLIKE is alias for REGEXP in F.expr()."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame(
+        [
+            {"Name": "Alice", "Value": "sales"},
+            {"Name": "Bob", "Value": "tech"},
+            {"Name": "Charlie", "Value": "ceo"},
+        ]
+    )
+    df = df.filter(F_backend.expr("Value RLIKE 'sales|tech'"))
+    rows = df.collect()
+    assert len(rows) == 2
+    names = {r["Name"] for r in rows}
+    assert names == {"Alice", "Bob"}
+
+
+def test_expr_regexp_with_column(spark, spark_backend):
+    """F.expr with REGEXP used in withColumn."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame(
+        [
+            {"Name": "Alice", "Value": "sales dept"},
+            {"Name": "Bob", "Value": "tech dept"},
+            {"Name": "Charlie", "Value": "ceo"},
+        ]
+    )
+    df = df.withColumn("matches", F_backend.expr("Value REGEXP 'sales|tech'"))
+    rows = df.collect()
+    alice = next(r for r in rows if r["Name"] == "Alice")
+    bob = next(r for r in rows if r["Name"] == "Bob")
+    charlie = next(r for r in rows if r["Name"] == "Charlie")
+    assert alice["matches"] is True
+    assert bob["matches"] is True
+    assert charlie["matches"] is False
+
+
+def test_expr_regexp_single_match(spark, spark_backend):
+    """REGEXP with single pattern match."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame([{"s": "hello world"}, {"s": "goodbye"}])
+    df = df.filter(F_backend.expr("s REGEXP 'hello'"))
+    rows = df.collect()
+    assert len(rows) == 1
+    assert rows[0]["s"] == "hello world"
+
+
+def test_expr_regexp_no_match(spark, spark_backend):
+    """REGEXP returns empty when no rows match."""
+    F_backend = get_spark_imports(spark_backend).F
+    df = spark.createDataFrame([{"Name": "Alice"}, {"Name": "Bob"}])
+    df = df.filter(F_backend.expr("Name REGEXP 'xyz'"))
+    rows = df.collect()
+    assert len(rows) == 0


### PR DESCRIPTION
## Summary
Fixes #433

`F.expr("Value REGEXP 'sales|tech'")` raised `ParseException: Invalid identifier or literal`. PySpark supports REGEXP and RLIKE in expression strings.

## Root cause
SQLExprParser did not recognize `REGEXP` or `RLIKE` as binary operators, so the entire expression fell through to `_parse_simple_value()` which treated it as an invalid identifier.

## Solution
Add parsing for `col REGEXP 'pattern'` and `col RLIKE 'pattern'` in `sql_expr_parser.py`, mirroring the existing LIKE handling. Both map to `StringFunctions.regexp()` (alias for rlike).

## Tests
Added regression tests in `tests/test_issue_433_regexp_in_expr.py`:
- `test_filter_regexp_exact_issue_433` - exact scenario from issue
- `test_filter_rlike_same_as_regexp` - RLIKE alias
- `test_expr_regexp_with_column` - withColumn
- `test_expr_regexp_single_match` / `test_expr_regexp_no_match`

All tests pass in both mock and PySpark modes.

Made with [Cursor](https://cursor.com)