### PR TITLE
fix: use float() for string coercion (PySpark parity) - follow-up to #455

### DIFF
--- a/sparkless/dataframe/grouped/base.py
+++ b/sparkless/dataframe/grouped/base.py
@@ -800,14 +800,10 @@ class GroupedData:
                             # Coerce booleans to ints to mirror Spark when user casts
                             if isinstance(expr_result, bool):
                                 expr_result = 1 if expr_result else 0
-                            # Convert numeric-looking strings
+                            # Convert numeric-looking strings (PySpark parity: cast to double)
                             if isinstance(expr_result, str):
                                 try:
-                                    expr_result = (
-                                        float(expr_result)
-                                        if "." in expr_result
-                                        else int(expr_result)
-                                    )
+                                    expr_result = float(expr_result)
                                 except ValueError:
                                     continue
                             values.append(expr_result)
@@ -855,7 +851,7 @@ class GroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)
@@ -877,11 +873,7 @@ class GroupedData:
                                 expr_result = 1 if expr_result else 0
                             if isinstance(expr_result, str):
                                 try:
-                                    expr_result = (
-                                        float(expr_result)
-                                        if "." in expr_result
-                                        else int(expr_result)
-                                    )
+                                    expr_result = float(expr_result)
                                 except ValueError:
                                     continue
                             values.append(expr_result)
@@ -929,7 +921,7 @@ class GroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)
@@ -1063,7 +1055,7 @@ class GroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)
@@ -1086,7 +1078,7 @@ class GroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     # Only add if not seen before
@@ -1275,7 +1267,7 @@ class GroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)

--- a/sparkless/dataframe/grouped/pivot.py
+++ b/sparkless/dataframe/grouped/pivot.py
@@ -420,7 +420,7 @@ class PivotGroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)
@@ -435,7 +435,7 @@ class PivotGroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)
@@ -536,7 +536,7 @@ class PivotGroupedData:
                         val = 1 if val else 0
                     if isinstance(val, str):
                         try:
-                            val = float(val) if "." in val else int(val)
+                            val = float(val)
                         except ValueError:
                             continue
                     values.append(val)

--- a/tests/test_issue_437_mean_string_column.py
+++ b/tests/test_issue_437_mean_string_column.py
@@ -7,6 +7,8 @@ F.mean() on string columns. Sparkless now coerces string columns to numeric
 (PySpark parity).
 """
 
+import math
+
 from tests.fixtures.spark_imports import get_spark_imports
 
 
@@ -82,3 +84,155 @@ class TestIssue437MeanStringColumn:
         rows = df.collect()
         assert len(rows) == 1
         assert abs(_norm(rows[0]["avg(Value)"]) - 2.5) < 1e-9
+
+    def test_mean_string_column_with_nulls(self, spark):
+        """F.mean() on string column with nulls - nulls excluded from mean."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "10"},
+                {"Type": "A", "Value": None},
+                {"Type": "A", "Value": "20"},
+                {"Type": "A", "Value": "30"},
+            ]
+        )
+        df = df.groupBy("Type").agg(F.mean("Value"))
+        rows = df.collect()
+        assert len(rows) == 1
+        # (10 + 20 + 30) / 3 = 20.0
+        assert _norm(rows[0]["avg(Value)"]) == 20.0
+
+    def test_mean_string_column_single_row_per_group(self, spark):
+        """F.mean() on string column with single row per group."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "42"},
+                {"Type": "B", "Value": "100"},
+            ]
+        )
+        df = df.groupBy("Type").agg(F.mean("Value"))
+        rows = df.collect()
+        assert len(rows) == 2
+        a_row = next(r for r in rows if r["Type"] == "A")
+        b_row = next(r for r in rows if r["Type"] == "B")
+        assert _norm(a_row["avg(Value)"]) == 42.0
+        assert _norm(b_row["avg(Value)"]) == 100.0
+
+    def test_avg_string_column_same_as_mean(self, spark):
+        """F.avg() on string column - same behavior as F.mean()."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "1"},
+                {"Type": "A", "Value": "2"},
+                {"Type": "A", "Value": "3"},
+            ]
+        )
+        df = df.groupBy("Type").agg(F.avg("Value"))
+        rows = df.collect()
+        assert len(rows) == 1
+        assert _norm(rows[0]["avg(Value)"]) == 2.0
+
+    def test_mean_string_column_multiple_aggregations(self, spark):
+        """F.mean() + F.sum() + F.count() on string column."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "10"},
+                {"Type": "A", "Value": "20"},
+                {"Type": "A", "Value": "30"},
+                {"Type": "B", "Value": "5"},
+            ]
+        )
+        df = df.groupBy("Type").agg(
+            F.mean("Value").alias("avg_val"),
+            F.sum("Value").alias("sum_val"),
+            F.count("Value").alias("cnt_val"),
+        )
+        rows = df.collect()
+        a_row = next(r for r in rows if r["Type"] == "A")
+        b_row = next(r for r in rows if r["Type"] == "B")
+        assert _norm(a_row["avg_val"]) == 20.0
+        assert _norm(a_row["sum_val"]) == 60.0
+        assert a_row["cnt_val"] == 3
+        assert _norm(b_row["avg_val"]) == 5.0
+        assert _norm(b_row["sum_val"]) == 5.0
+        assert b_row["cnt_val"] == 1
+
+    def test_mean_string_column_select_after(self, spark):
+        """F.mean() on string column, then select."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "10"},
+                {"Type": "A", "Value": "20"},
+                {"Type": "B", "Value": "5"},
+            ]
+        )
+        result = df.groupBy("Type").agg(F.mean("Value")).select("Type", "avg(Value)")
+        rows = result.collect()
+        assert len(rows) == 2
+        a_row = next(r for r in rows if r["Type"] == "A")
+        b_row = next(r for r in rows if r["Type"] == "B")
+        assert _norm(a_row["avg(Value)"]) == 15.0
+        assert _norm(b_row["avg(Value)"]) == 5.0
+
+    def test_mean_string_column_scientific_notation(self, spark):
+        """F.mean() on string column with scientific notation (PySpark parity)."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "1e2"},
+                {"Type": "A", "Value": "2e2"},
+                {"Type": "A", "Value": "3e2"},
+            ]
+        )
+        df = df.groupBy("Type").agg(F.mean("Value"))
+        rows = df.collect()
+        assert len(rows) == 1
+        # 100 + 200 + 300 = 600, mean = 200
+        assert abs(_norm(rows[0]["avg(Value)"]) - 200.0) < 1e-6
+
+    def test_mean_string_column_mixed_int_float_strings(self, spark):
+        """F.mean() on string column with mixed '1' and '1.0' style values."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "1"},
+                {"Type": "A", "Value": "2.0"},
+                {"Type": "A", "Value": "3"},
+            ]
+        )
+        df = df.groupBy("Type").agg(F.mean("Value"))
+        rows = df.collect()
+        assert len(rows) == 1
+        assert abs(_norm(rows[0]["avg(Value)"]) - 2.0) < 1e-9
+
+    def test_mean_string_column_all_nulls_returns_none(self, spark):
+        """F.mean() on string column with all nulls in group returns None/NaN."""
+        imports = get_spark_imports()
+        F = imports.F
+        df = spark.createDataFrame(
+            [
+                {"Type": "A", "Value": "10"},
+                {"Type": "B", "Value": None},
+                {"Type": "B", "Value": None},
+            ]
+        )
+        df = df.groupBy("Type").agg(F.mean("Value"))
+        rows = df.collect()
+        a_row = next(r for r in rows if r["Type"] == "A")
+        b_row = next(r for r in rows if r["Type"] == "B")
+        assert _norm(a_row["avg(Value)"]) == 10.0
+        # PySpark returns null for empty aggregate; sparkless may return None
+        assert b_row["avg(Value)"] is None or (
+            isinstance(b_row["avg(Value)"], float) and math.isnan(b_row["avg(Value)"])
+        )


### PR DESCRIPTION
Follow-up to PR #455 (fixes #437). Adds the commit that was pushed after #455 was merged:

- **PySpark parity**: Replace `float(val) if '.' in val else int(val)` with `float(val)` to support scientific notation (e.g. `1e2`, `2.5e-1`) and match PySpark's implicit double cast
- **Robust tests**: Add test_mean_string_column_with_nulls, single_row_per_group, avg_same_as_mean, multiple_aggregations, select_after, scientific_notation, mixed_int_float, all_nulls_returns_none

All 11 tests pass in PySpark and mock mode.

Made with [Cursor](https://cursor.com)