### PR TITLE
test: verify Robin concat(col, lit, col) uses materializer (#474)

### DIFF
--- a/sparkless/functions/functions.py
+++ b/sparkless/functions/functions.py
@@ -307,7 +307,7 @@ class Functions:
         return StringFunctions.substring(column, start, length)
 
     @staticmethod
-    def concat(*columns: Union[Column, str]) -> ColumnOperation:
+    def concat(*columns: Union[Column, str, Literal]) -> ColumnOperation:
         """Concatenate strings."""
         return StringFunctions.concat(*columns)
 

--- a/sparkless/functions/string.py
+++ b/sparkless/functions/string.py
@@ -30,7 +30,9 @@ Example:
 """
 
 from typing import Any, Optional, Union
+
 from sparkless.functions.base import Column, ColumnOperation
+from sparkless.functions.core.literals import Literal
 
 
 class StringFunctions:
@@ -615,11 +617,11 @@ class StringFunctions:
         return operation
 
     @staticmethod
-    def concat(*columns: Union[Column, str]) -> ColumnOperation:
+    def concat(*columns: Union[Column, str, Literal]) -> ColumnOperation:
         """Concatenate multiple strings.
 
         Args:
-            *columns: Columns or strings to concatenate.
+            *columns: Columns, strings, or literals (e.g. F.lit(sep)) to concatenate.
 
         Returns:
             ColumnOperation representing the concat function.


### PR DESCRIPTION
## Summary
Fixes #474 by adding a Robin backend test that verifies `concat(col, lit(sep), col)` is translated correctly (via the existing concat → concat_ws logic in the materializer).

## Changes
- **tests/unit/backend/test_robin_materializer.py**: Add `test_concat_with_literal_separator_robin`, which uses the Robin backend to run:
  - `df.withColumn("full_name", F.concat(F.col("first_name"), F.lit(" "), F.col("last_name")))`
  - Asserts that the resulting `full_name` values are `"alice x"` and `"bob y"`.

The materializer already contains a concat branch that detects exactly one string `Literal` among the parts and routes to `concat_ws`; this test ensures that behavior is covered in CI for the Robin backend.

Made with [Cursor](https://cursor.com)