### PR TITLE
fix: Robin materializer empty schema edge case (#475)

### DIFF
--- a/sparkless/backend/robin/materializer.py
+++ b/sparkless/backend/robin/materializer.py
@@ -1151,7 +1151,15 @@ class RobinMaterializer:
             )
         F = robin_sparkless  # type: ignore[union-attr]
         if not schema.fields:
-            raise ValueError("RobinMaterializer requires a non-empty schema")
+            if not operations:
+                # No-op: return data as rows with empty schema (#475)
+                rows = _data_to_robin_rows(data, [])
+                result: List[Row] = [Row(d, schema=schema) for d in rows]
+                return result
+            raise ValueError(
+                "Robin backend does not support empty schema when operations are "
+                "applied; ensure at least one column."
+            )
         # For initial creation, use columns from data to support operations like drop().
         # The passed schema may be the final projected schema (e.g. after drop) which
         # would omit columns we need for intermediate ops. Use data keys first.


### PR DESCRIPTION
## Summary
Fixes #475: handle empty schema in Robin materializer deterministically.

## Changes
- **materializer.py**: When `schema.fields` is empty:
  - If `operations` is empty: return data as list of rows (no-op), using `_data_to_robin_rows(data, [])` and wrapping in `Row(..., schema=schema)`.
  - If `operations` is non-empty: raise a clear `ValueError` with message "Robin backend does not support empty schema when operations are applied; ensure at least one column."
- **test_robin_materializer.py**: Add `TestRobinMaterializerEmptySchema` with:
  - `test_empty_schema_no_operations_returns_rows`: `materialize([], StructType([]), [])` returns `[]`.
  - `test_empty_schema_with_operations_raises`: `materialize([], StructType([]), [("limit", 5)])` raises `ValueError` matching "does not support empty schema when".

Made with [Cursor](https://cursor.com)