### PR TITLE
fix: Test collection errors for parquet, backend_capability, issue_160 (#476)

### DIFF
--- a/tests/parity/dataframe/test_parquet_format_table_append.py
+++ b/tests/parity/dataframe/test_parquet_format_table_append.py
@@ -8,7 +8,6 @@ import pytest
 from tests.fixtures.parity_base import ParityTestBase
 from sparkless.spark_types import StructType, StructField, IntegerType, StringType
 from sparkless.sql import SparkSession
-from sparkless.backend.polars.storage import PolarsStorageManager
 
 
 class TestParquetFormatTableAppend(ParityTestBase):
@@ -228,6 +227,9 @@ class TestParquetFormatTableAppend(ParityTestBase):
 
     def test_storage_manager_detached_write_visible_to_session(self, spark):
         """Writes via a standalone PolarsStorageManager should surface in the active session."""
+        pytest.importorskip("polars")
+        from sparkless.backend.polars.storage import PolarsStorageManager
+
         schema = StructType(
             [
                 StructField("id", IntegerType(), True),

--- a/tests/test_backend_capability_model.py
+++ b/tests/test_backend_capability_model.py
@@ -4,6 +4,9 @@ This module tests the capability checking functionality in materializers,
 ensuring that unsupported operations are detected upfront and raise clear errors.
 """
 
+import pytest
+
+pytest.importorskip("polars")
 from sparkless import SparkSession, functions as F
 from sparkless.window import Window
 from sparkless.backend.polars.materializer import PolarsMaterializer

--- a/tests/test_issue_160_manual_cache_manipulation.py
+++ b/tests/test_issue_160_manual_cache_manipulation.py
@@ -9,9 +9,12 @@ This test tries to force the bug by:
 
 import os
 import pytest
+
+pytest.importorskip("polars")
+import polars as pl
+
 from sparkless import SparkSession, functions as F
 from sparkless.backend.factory import BackendFactory
-import polars as pl
 
 
 @pytest.fixture

--- a/tests/test_issue_160_nested_operations.py
+++ b/tests/test_issue_160_nested_operations.py
@@ -10,8 +10,11 @@ The bug might occur when:
 
 import os
 import pytest
-from sparkless import SparkSession, functions as F
+
+pytest.importorskip("polars")
 import polars as pl
+
+from sparkless import SparkSession, functions as F
 
 
 @pytest.fixture

--- a/tests/unit/v4_robin_skip_list.txt
+++ b/tests/unit/v4_robin_skip_list.txt
@@ -89,3 +89,7 @@ tests/unit/backend/test_robin_unsupported_raises.py::TestRobinUnsupportedRaises:
 tests/unit/backend/test_robin_unsupported_raises.py::TestRobinUnsupportedRaises::test_unsupported_raises_with_clear_message
 # window arithmetic
 tests/unit/test_window_arithmetic.py
+# Polars-only: backend capability model and issue 160 cache tests (#476)
+tests/test_backend_capability_model.py
+tests/test_issue_160_manual_cache_manipulation.py
+tests/test_issue_160_nested_operations.py


### PR DESCRIPTION
## Summary
Fixes #476: pytest collection no longer fails for the four modules when running with Robin backend (or when Polars is not installed).

## Changes
- **test_parquet_format_table_append.py**: Removed top-level `PolarsStorageManager` import. The test that uses it (`test_storage_manager_detached_write_visible_to_session`) now calls `pytest.importorskip("polars")` and imports `PolarsStorageManager` locally, so the module collects successfully when Polars is missing.
- **test_backend_capability_model.py**: Added `pytest.importorskip("polars")` before importing `PolarsMaterializer`, so the module is skipped at collection when Polars is not installed (no ImportError).
- **test_issue_160_manual_cache_manipulation.py** and **test_issue_160_nested_operations.py**: Added `pytest.importorskip("polars")` before `import polars as pl`, so collection succeeds when Polars is not installed.
- **v4_robin_skip_list.txt**: Added the three Polars-only test modules (`test_backend_capability_model.py`, `test_issue_160_manual_cache_manipulation.py`, `test_issue_160_nested_operations.py`) so they are skipped when `SPARKLESS_TEST_BACKEND=robin`.

## Verification
With `SPARKLESS_TEST_BACKEND=robin` and no Polars installed, `pytest tests/parity/dataframe/test_parquet_format_table_append.py tests/test_backend_capability_model.py tests/test_issue_160_manual_cache_manipulation.py tests/test_issue_160_nested_operations.py --collect-only` completes with 0 collection errors (parquet tests collected; other modules skipped via importorskip).

Made with [Cursor](https://cursor.com)